### PR TITLE
fix memory leaks

### DIFF
--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -23,6 +23,8 @@ enum err {
 	buffer_to_small = 1,
 	hkdf_fialed = 2,
 	unexpected_result_from_ext_lib = 3,
+	wrong_parameter = 4,
+	crypto_operation_not_implemented = 5,
 
 	/*EDHOC specifc errors*/
 	/*todo implement error messages*/

--- a/src/common/crypto_wrapper.c
+++ b/src/common/crypto_wrapper.c
@@ -8,18 +8,17 @@
    option. This file may not be copied, modified, or distributed
    except according to those terms.
 */
-
 #include <string.h>
 
 #include "edhoc.h"
-
-#include "edhoc/suites.h"
 
 #include "common/crypto_wrapper.h"
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
 #include "common/print_util.h"
 #include "common/memcpy_s.h"
+
+#include "edhoc/suites.h"
 
 //#define MBEDTLS
 
@@ -62,7 +61,21 @@ modify setting in include/psa/crypto_config.h
 #include <tinycrypt/ecc_dh.h>
 #endif
 
+
 #ifdef MBEDTLS
+#define TRY_EXPECT_PSA(x, expected_result, key_id, err_code)                \
+	do {                                                                    \
+		int retval = (int)(x);                                              \
+		if ((expected_result) != retval) {                                  \
+			if(PSA_KEY_HANDLE_INIT != (key_id)) {                           \
+				psa_destroy_key(key_id);                                    \
+			}                                                               \
+			PRINTF(RED                                                      \
+			       "Runtime error: %s error code %d at %s:%d\n\n" RESET,    \
+			       #x, retval, __FILE__, __LINE__);                         \
+			return err_code;                                                \
+		}                                                                   \
+	} while (0)
 
 /**
  * @brief Decompresses an elliptic curve point. 
@@ -185,9 +198,10 @@ aead(enum aes_operation op, const uint8_t *in, const uint32_t in_len,
 	}
 #endif
 #ifdef MBEDTLS
-	psa_key_id_t key_id = 0;
+	psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 
-	TRY_EXPECT(psa_crypto_init(), 0);
+	TRY_EXPECT_PSA(psa_crypto_init(),
+				   PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
 	psa_algorithm_t alg =
 		PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, (uint32_t)tag_len);
@@ -197,26 +211,27 @@ aead(enum aes_operation op, const uint8_t *in, const uint32_t in_len,
 				PSA_KEY_USAGE_DECRYPT | PSA_KEY_USAGE_ENCRYPT);
 	psa_set_key_algorithm(&attr, alg);
 	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
-	psa_set_key_bits(&attr, (size_t)(key_len << 3));
+	psa_set_key_bits(&attr, ((size_t)key_len << 3));
 	psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
-	TRY_EXPECT(psa_import_key(&attr, key, key_len, &key_id), 0);
+	TRY_EXPECT_PSA(psa_import_key(&attr, key, key_len, &key_id),
+				   PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
 	if (op == DECRYPT) {
 		size_t out_len_re = 0;
-		TRY_EXPECT(psa_aead_decrypt(key_id, alg, nonce, nonce_len, aad,
+		TRY_EXPECT_PSA(psa_aead_decrypt(key_id, alg, nonce, nonce_len, aad,
 					    aad_len, in, in_len, out, out_len,
 					    &out_len_re),
-			   0);
+						PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 	} else {
 		size_t out_len_re;
-		TRY_EXPECT(psa_aead_encrypt(key_id, alg, nonce, nonce_len, aad,
+		TRY_EXPECT_PSA(psa_aead_encrypt(key_id, alg, nonce, nonce_len, aad,
 					    aad_len, in, in_len, out,
 					    (size_t)(in_len + tag_len),
 					    &out_len_re),
-			   0);
+						PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 		memcpy(tag, out + out_len_re - tag_len, tag_len);
 	}
-	TRY_EXPECT(psa_destroy_key(key_id), 0);
+	TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
 
 #endif
 	return ok;
@@ -236,17 +251,16 @@ sign(enum sign_alg alg, const uint8_t *sk, const uint32_t sk_len,
 #if defined(MBEDTLS)
 		psa_algorithm_t psa_alg;
 		size_t bits;
+		psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 
 		psa_alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 		bits = PSA_BYTES_TO_BITS((size_t)sk_len);
 
-		TRY_EXPECT(psa_crypto_init(), 0);
+		TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
-		psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 		psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-
 		psa_set_key_usage_flags(&attributes,
-					PSA_KEY_USAGE_VERIFY_MESSAGE |
+						PSA_KEY_USAGE_VERIFY_MESSAGE |
 						PSA_KEY_USAGE_VERIFY_HASH |
 						PSA_KEY_USAGE_SIGN_MESSAGE |
 						PSA_KEY_USAGE_SIGN_HASH);
@@ -256,18 +270,18 @@ sign(enum sign_alg alg, const uint8_t *sk, const uint32_t sk_len,
 		psa_set_key_bits(&attributes, bits);
 		psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
 
-		TRY_EXPECT(psa_import_key(&attributes, sk, sk_len, &key_id), 0);
+		TRY_EXPECT_PSA(psa_import_key(&attributes, sk, sk_len, &key_id),
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+
 		size_t signature_length;
-
-		TRY_EXPECT(psa_sign_message(key_id, psa_alg, msg, msg_len, out,
-					    SIGNATURE_DEFAULT_SIZE,
+		TRY_EXPECT_PSA(psa_sign_message(key_id, psa_alg, msg, msg_len, out,
+						SIGNATURE_DEFAULT_SIZE,
 					    &signature_length),
-			   0);
-		if (signature_length != SIGNATURE_DEFAULT_SIZE) {
-			return sign_failed;
-		}
-		return ok;
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
+		TRY_EXPECT_PSA(signature_length, SIGNATURE_DEFAULT_SIZE, key_id, sign_failed);
+		TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+		return ok;
 #endif
 	}
 	return unsupported_ecdh_curve;
@@ -286,6 +300,7 @@ verify(enum sign_alg alg, const uint8_t *pk, const uint32_t pk_len,
 		} else {
 			*result = false;
 		}
+		return ok;
 #endif
 	}
 	if (alg == ES256) {
@@ -293,13 +308,13 @@ verify(enum sign_alg alg, const uint8_t *pk, const uint32_t pk_len,
 		psa_status_t status;
 		psa_algorithm_t psa_alg;
 		size_t bits;
+		psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 
 		psa_alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 		bits = PSA_BYTES_TO_BITS(P_256_PRIV_KEY_DEFAULT_SIZE);
 
-		TRY_EXPECT(psa_crypto_init(), 0);
+		TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
-		psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 		psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
 		psa_set_key_usage_flags(&attributes,
@@ -309,7 +324,8 @@ verify(enum sign_alg alg, const uint8_t *pk, const uint32_t pk_len,
 		psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_PUBLIC_KEY(
 						      PSA_ECC_FAMILY_SECP_R1));
 		psa_set_key_bits(&attributes, bits);
-		TRY_EXPECT(psa_import_key(&attributes, pk, pk_len, &key_id), 0);
+		TRY_EXPECT_PSA(psa_import_key(&attributes, pk, pk_len, &key_id),
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
 		status = psa_verify_message(key_id, psa_alg, msg, msg_len, sgn,
 					    sgn_len);
@@ -318,10 +334,11 @@ verify(enum sign_alg alg, const uint8_t *pk, const uint32_t pk_len,
 		} else {
 			*result = false;
 		}
-		TRY_EXPECT(psa_destroy_key(key_id), 0);
+		TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+		return ok;
 #endif
 	}
-	return ok;
+	return crypto_operation_not_implemented;
 }
 
 enum err __attribute__((weak))
@@ -334,47 +351,49 @@ hkdf_extract(enum hash_alg alg, const uint8_t *salt, uint32_t salt_len,
 	is converted to a string of zeroes (see Section 2.2 of [RFC5869])".*/
 
 	/*all currently prosed suites use hmac-sha256*/
-	if (alg == SHA_256) {
+	if (alg != SHA_256) {
+		return crypto_operation_not_implemented;
+	}
 #ifdef TINYCRYPT
-		struct tc_hmac_state_struct h;
-		memset(&h, 0x00, sizeof(h));
-		if (salt == NULL || salt_len == 0) {
-			uint8_t zero_salt[32] = { 0 };
-			TRY_EXPECT(tc_hmac_set_key(&h, zero_salt, 32), 1);
-		} else {
-			TRY_EXPECT(tc_hmac_set_key(&h, salt, salt_len), 1);
-		}
-		TRY_EXPECT(tc_hmac_init(&h), 1);
-		TRY_EXPECT(tc_hmac_update(&h, ikm, ikm_len), 1);
-		TRY_EXPECT(tc_hmac_final(out, TC_SHA256_DIGEST_SIZE, &h), 1);
+	struct tc_hmac_state_struct h;
+	memset(&h, 0x00, sizeof(h));
+	if (salt == NULL || salt_len == 0) {
+		uint8_t zero_salt[32] = { 0 };
+		TRY_EXPECT(tc_hmac_set_key(&h, zero_salt, 32), 1);
+	} else {
+		TRY_EXPECT(tc_hmac_set_key(&h, salt, salt_len), 1);
+	}
+	TRY_EXPECT(tc_hmac_init(&h), 1);
+	TRY_EXPECT(tc_hmac_update(&h, ikm, ikm_len), 1);
+	TRY_EXPECT(tc_hmac_final(out, TC_SHA256_DIGEST_SIZE, &h), 1);
 #endif
 #ifdef MBEDTLS
-		TRY_EXPECT(psa_crypto_init(), 0);
-		psa_algorithm_t psa_alg = PSA_ALG_HMAC(PSA_ALG_SHA_256);
-		psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
-		psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
-		psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_HASH);
-		psa_set_key_algorithm(&attr, psa_alg);
-		psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
-		psa_key_id_t key_id = 0;
-		if (salt && salt_len) {
-			TRY_EXPECT(psa_import_key(&attr, salt, salt_len,
-						  &key_id),
-				   0);
-		} else {
-			uint8_t zero_salt[32] = { 0 };
-			TRY_EXPECT(psa_import_key(&attr, zero_salt, 32,
-						  &key_id),
-				   0);
-		}
-		size_t out_len;
-		TRY_EXPECT(psa_mac_compute(key_id, psa_alg, ikm, ikm_len, out,
-					   32, &out_len),
-			   0);
-		TRY_EXPECT(psa_destroy_key(key_id), 0);
+	psa_algorithm_t psa_alg = PSA_ALG_HMAC(PSA_ALG_SHA_256);
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 
-#endif
+	TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+
+	psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_HASH);
+	psa_set_key_algorithm(&attr, psa_alg);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+
+	if (salt && salt_len) {
+		TRY_EXPECT_PSA(psa_import_key(&attr, salt, salt_len, &key_id),
+					PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+	} else {
+		uint8_t zero_salt[32] = { 0 };
+
+		TRY_EXPECT_PSA(psa_import_key(&attr, zero_salt, 32, &key_id),
+						PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 	}
+	size_t out_len;
+	TRY_EXPECT_PSA(psa_mac_compute(key_id, psa_alg, ikm, ikm_len, out, 32, &out_len),
+					PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+
+	TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+#endif
 	return ok;
 }
 
@@ -383,83 +402,81 @@ hkdf_expand(enum hash_alg alg, const uint8_t *prk, const uint32_t prk_len,
 	    const uint8_t *info, const uint32_t info_len, uint8_t *out,
 	    uint32_t out_len)
 {
-	if (alg == SHA_256) {
-		/* "N = ceil(L/HashLen)" */
-		uint32_t iterations = (out_len + 31) / 32;
-		/* "L length of output keying material in octets (<= 255*HashLen)"*/
-		if (iterations > 255) {
-			return hkdf_fialed;
-		}
+	if (alg != SHA_256) {
+		return crypto_operation_not_implemented;
+	}
+	/* "N = ceil(L/HashLen)" */
+	uint32_t iterations = (out_len + 31) / 32;
+	/* "L length of output keying material in octets (<= 255*HashLen)"*/
+	if (iterations > 255) {
+		return hkdf_fialed;
+	}
 
 #ifdef TINYCRYPT
-		uint8_t t[32] = { 0 };
-		struct tc_hmac_state_struct h;
-		for (uint8_t i = 1; i <= iterations; i++) {
-			memset(&h, 0x00, sizeof(h));
-			TRY_EXPECT(tc_hmac_set_key(&h, prk, prk_len), 1);
-			tc_hmac_init(&h);
-			if (i > 1) {
-				TRY_EXPECT(tc_hmac_update(&h, t, 32), 1);
-			}
-			TRY_EXPECT(tc_hmac_update(&h, info, info_len), 1);
-			TRY_EXPECT(tc_hmac_update(&h, &i, 1), 1);
-			TRY_EXPECT(tc_hmac_final(t, TC_SHA256_DIGEST_SIZE, &h),
-				   1);
-			if (out_len < i * 32) {
-				memcpy(&out[(i - 1) * 32], t, out_len % 32);
-			} else {
-				memcpy(&out[(i - 1) * 32], t, 32);
-			}
+	uint8_t t[32] = { 0 };
+	struct tc_hmac_state_struct h;
+	for (uint8_t i = 1; i <= iterations; i++) {
+		memset(&h, 0x00, sizeof(h));
+		TRY_EXPECT(tc_hmac_set_key(&h, prk, prk_len), 1);
+		tc_hmac_init(&h);
+		if (i > 1) {
+			TRY_EXPECT(tc_hmac_update(&h, t, 32), 1);
 		}
+		TRY_EXPECT(tc_hmac_update(&h, info, info_len), 1);
+		TRY_EXPECT(tc_hmac_update(&h, &i, 1), 1);
+		TRY_EXPECT(tc_hmac_final(t, TC_SHA256_DIGEST_SIZE, &h),
+				1);
+		if (out_len < i * 32) {
+			memcpy(&out[(i - 1) * 32], t, out_len % 32);
+		} else {
+			memcpy(&out[(i - 1) * 32], t, 32);
+		}
+	}
 #endif
 #ifdef MBEDTLS
-		psa_status_t status;
-		TRY_EXPECT(psa_crypto_init(), 0);
+	psa_status_t status;
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 
-		psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
-		psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
-		psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_HASH);
-		psa_set_key_algorithm(&attr, PSA_ALG_HMAC(PSA_ALG_SHA_256));
-		psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
-		psa_key_id_t key_id = 0;
-		TRY_EXPECT(psa_import_key(&attr, prk, prk_len, &key_id), 0);
-		size_t combo_len = (size_t)(32 + info_len + 1);
+	TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+	psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_HASH);
+	psa_set_key_algorithm(&attr, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+	psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
 
-		TRY(check_buffer_size(INFO_DEFAULT_SIZE, (uint32_t)combo_len));
+	TRY_EXPECT_PSA(psa_import_key(&attr, prk, prk_len, &key_id),
+					PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
-		uint8_t combo[INFO_DEFAULT_SIZE];
-		uint8_t tmp_out[32];
-		memset(tmp_out, 0, 32);
-		memcpy(combo + 32, info, info_len);
-		size_t offset = 32;
-		for (uint8_t i = 1; i <= iterations; i++) {
-			memcpy(combo, tmp_out, 32);
-			combo[combo_len - 1] = i;
-			size_t tmp_out_len;
-			status = psa_mac_compute(key_id,
-						 PSA_ALG_HMAC(PSA_ALG_SHA_256),
-						 combo + offset,
-						 combo_len - offset, tmp_out,
-						 32, &tmp_out_len);
-			if (PSA_SUCCESS != status) {
-				psa_destroy_key(key_id);
-				key_id = 0;
-				return unexpected_result_from_ext_lib;
-			}
-			offset = 0;
-			uint8_t *dest = out + ((i - 1) << 5);
-			if (out_len < (uint32_t)(i << 5)) {
-				memcpy(dest, tmp_out, out_len & 31);
-			} else {
-				memcpy(dest, tmp_out, 32);
-			}
+	size_t combo_len = (32 + (size_t)info_len + 1);
+
+	TRY_EXPECT_PSA(check_buffer_size(INFO_DEFAULT_SIZE, (uint32_t)combo_len),
+					ok, key_id, unexpected_result_from_ext_lib);
+
+	uint8_t combo[INFO_DEFAULT_SIZE];
+	uint8_t tmp_out[32];
+	memset(tmp_out, 0, 32);
+	memcpy(combo + 32, info, info_len);
+	size_t offset = 32;
+	for (uint32_t i = 1; i <= iterations; i++) {
+		memcpy(combo, tmp_out, 32);
+		combo[combo_len - 1] = (uint8_t)i;
+		size_t tmp_out_len;
+		status = psa_mac_compute(key_id,
+						PSA_ALG_HMAC(PSA_ALG_SHA_256),
+						combo + offset,
+						combo_len - offset, tmp_out,
+						32, &tmp_out_len);
+		TRY_EXPECT_PSA(status, PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+		offset = 0;
+		uint8_t *dest = out + ((i - 1) << 5);
+		if (out_len < (uint32_t)(i << 5)) {
+			memcpy(dest, tmp_out, out_len & 31);
+		} else {
+			memcpy(dest, tmp_out, 32);
 		}
-		if (key_id) {
-			psa_destroy_key(key_id);
-		}
-
-#endif
 	}
+	TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+#endif
 	return ok;
 }
 
@@ -487,18 +504,20 @@ shared_secret_derive(enum ecdh_alg alg, const uint8_t *sk,
 		f25519_copy(e, sk);
 		c25519_prepare(e);
 		c25519_smult(shared_secret, pk, e);
+		return ok;
 #endif
 	}
 	if (alg == P256) {
 #ifdef MBEDTLS
-		psa_key_id_t key_id;
+		psa_key_id_t key_id = PSA_KEY_HANDLE_INIT;
 		psa_algorithm_t psa_alg;
 		size_t bits;
+		psa_status_t result = ok;
 
 		psa_alg = PSA_ALG_ECDH;
 		bits = PSA_BYTES_TO_BITS(sk_len);
 
-		TRY_EXPECT(psa_crypto_init(), 0);
+		TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
 		psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
 		psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
@@ -506,7 +525,9 @@ shared_secret_derive(enum ecdh_alg alg, const uint8_t *sk,
 		psa_set_key_algorithm(&attr, psa_alg);
 		psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(
 						PSA_ECC_FAMILY_SECP_R1));
-		psa_import_key(&attr, sk, (size_t)sk_len, &key_id);
+
+        TRY_EXPECT_PSA(psa_import_key(&attr, sk, (size_t)sk_len, &key_id),
+					PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 		psa_key_type_t type = psa_get_key_type(&attr);
 		size_t shared_size =
 			PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE(type, bits);
@@ -517,36 +538,46 @@ shared_secret_derive(enum ecdh_alg alg, const uint8_t *sk,
 		size_t pk_decompressed_len;
 		uint8_t pk_decompressed[P_256_PUB_KEY_UNCOMPRESSED_SIZE];
 
-		mbedtls_pk_context ctx_verify;
+		mbedtls_pk_context ctx_verify = {0};
 		mbedtls_pk_init(&ctx_verify);
-		TRY_EXPECT(mbedtls_pk_setup(
-				   &ctx_verify,
-				   mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)),
-			   0);
-		TRY_EXPECT(
-			mbedtls_ecp_group_load(&mbedtls_pk_ec(ctx_verify)->grp,
-					       MBEDTLS_ECP_DP_SECP256R1),
-			0);
-		TRY_EXPECT(mbedtls_ecp_decompress(
-				   &mbedtls_pk_ec(ctx_verify)->grp, pk, pk_len,
-				   pk_decompressed, &pk_decompressed_len,
-				   sizeof(pk_decompressed)),
-			   0);
+		if(PSA_SUCCESS != mbedtls_pk_setup(
+						&ctx_verify,
+						mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY))) {
+			result = unexpected_result_from_ext_lib;
+			goto cleanup;
+		}
+		if(PSA_SUCCESS != mbedtls_ecp_group_load(&mbedtls_pk_ec(ctx_verify)->grp,
+												MBEDTLS_ECP_DP_SECP256R1)){
+			result = unexpected_result_from_ext_lib;
+			goto cleanup;
+		}
+		if(PSA_SUCCESS != mbedtls_ecp_decompress(
+						&mbedtls_pk_ec(ctx_verify)->grp, pk, pk_len,
+						pk_decompressed, &pk_decompressed_len,
+						sizeof(pk_decompressed))){
+			result = unexpected_result_from_ext_lib;
+			goto cleanup;
+		}
 
 		PRINT_ARRAY("pk_decompressed", pk_decompressed,
 			    (uint32_t)pk_decompressed_len);
 
-		TRY_EXPECT(psa_raw_key_agreement(
-				   PSA_ALG_ECDH, key_id, pk_decompressed,
-				   pk_decompressed_len, shared_secret,
-				   shared_size, &shared_secret_len),
-			   0);
-		TRY_EXPECT(psa_destroy_key(key_id), 0);
-
+		if(PSA_SUCCESS != psa_raw_key_agreement(
+						PSA_ALG_ECDH, key_id, pk_decompressed,
+						pk_decompressed_len, shared_secret,
+						shared_size, &shared_secret_len)){
+			result = unexpected_result_from_ext_lib;
+			goto cleanup;
+		}
+cleanup:
+	if(PSA_KEY_HANDLE_INIT != key_id) {
+		TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+	}
+	mbedtls_pk_free(&ctx_verify);
+	return result;
 #endif
 	}
-
-	return ok;
+	return crypto_operation_not_implemented;
 }
 
 enum err __attribute__((weak))
@@ -589,11 +620,10 @@ ephemeral_dh_key_gen(enum ecdh_alg alg, uint32_t seed, uint8_t *sk,
 		if (P_256_PUB_KEY_COMPRESSED_SIZE > *pk_size) {
 			return buffer_to_small;
 		}
-
-		TRY_EXPECT(psa_crypto_init(), 0);
+		TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
 		psa_set_key_usage_flags(&attributes,
-					PSA_KEY_USAGE_EXPORT |
+						PSA_KEY_USAGE_EXPORT |
 						PSA_KEY_USAGE_DERIVE |
 						PSA_KEY_USAGE_SIGN_MESSAGE |
 						PSA_KEY_USAGE_SIGN_HASH);
@@ -602,20 +632,22 @@ ephemeral_dh_key_gen(enum ecdh_alg alg, uint32_t seed, uint8_t *sk,
 						      PSA_ECC_FAMILY_SECP_R1));
 		psa_set_key_bits(&attributes, bits);
 
-		TRY_EXPECT(psa_generate_key(&attributes, &key_id), 0);
+		TRY_EXPECT_PSA(psa_generate_key(&attributes, &key_id),
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
+		size_t key_len = 0;
 		size_t public_key_len = 0;
 
-		TRY_EXPECT(psa_export_public_key(key_id, pub_key_uncompressed, pub_key_uncompressed_size, &public_key_len),
-		               PSA_SUCCESS);
-		TRY_EXPECT(public_key_len, P_256_PUB_KEY_UNCOMPRESSED_SIZE);
+		TRY_EXPECT_PSA(psa_export_key(key_id, sk, priv_key_size, &key_len),
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+		TRY_EXPECT_PSA(psa_export_public_key(key_id, pub_key_uncompressed, pub_key_uncompressed_size, &public_key_len),
+		               PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
+		TRY_EXPECT_PSA(public_key_len, P_256_PUB_KEY_UNCOMPRESSED_SIZE, key_id, unexpected_result_from_ext_lib);
 		/* Prepare output format - compressed public key with X */
 		pk[0] = 0x02;	/* key format tag - commpressed for with X */
 		memcpy((pk + 1), (pub_key_uncompressed + 1), 32);
 		TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
 		*pk_size = P_256_PUB_KEY_COMPRESSED_SIZE;
-
-		return ok;
 #endif
 	} else {
 		return unsupported_ecdh_curve;
@@ -632,17 +664,19 @@ hash(enum hash_alg alg, const uint8_t *in, const uint32_t in_len, uint8_t *out)
 		TRY_EXPECT(tc_sha256_init(&s), 1);
 		TRY_EXPECT(tc_sha256_update(&s, in, in_len), 1);
 		TRY_EXPECT(tc_sha256_final(out, &s), 1);
+		return ok;
 #endif
 #ifdef MBEDTLS
 		size_t length;
 		TRY_EXPECT(psa_hash_compute(PSA_ALG_SHA_256, in, in_len, out,
 					    SHA_DEFAULT_SIZE, &length),
-			   0);
+				  PSA_SUCCESS);
 		if (length != SHA_DEFAULT_SIZE) {
 			return sha_failed;
 		}
+		return ok;
 #endif
 	}
 
-	return ok;
+	return crypto_operation_not_implemented;
 }


### PR DESCRIPTION
Fix memory leaks in crypto wrapper. Take care to always free allocated memory - destroy psa key and context.