### PR TITLE
Fix/rename oscore cose functions

### DIFF
--- a/inc/oscore/oscore_cose.h
+++ b/inc/oscore/oscore_cose.h
@@ -24,7 +24,7 @@
  * @param recipient_key the recipient key
  * @return err
  */
-enum err cose_decrypt(struct byte_array *in_ciphertext,
+enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
 		      struct byte_array *out_plaintext,
 		      struct byte_array *nonce, struct byte_array *aad,
 		      struct byte_array *recipient_key);
@@ -38,7 +38,7 @@ enum err cose_decrypt(struct byte_array *in_ciphertext,
  * @param sender_key the sender key
  * @return err
  */
-enum err cose_encrypt(struct byte_array *in_plaintext, uint8_t *out_ciphertext,
+enum err oscore_cose_encrypt(struct byte_array *in_plaintext, uint8_t *out_ciphertext,
 		      uint32_t out_ciphertext_len, struct byte_array *nonce,
 		      struct byte_array *sender_aad, struct byte_array *key);
 #endif

--- a/src/common/crypto_wrapper.c
+++ b/src/common/crypto_wrapper.c
@@ -34,7 +34,6 @@ modify setting in include/psa/crypto_config.h
 
 #include <psa/crypto.h>
 
-#include "mbedtls/mbedtls_config.h"
 #include "mbedtls/ecp.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/entropy.h"

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -198,7 +198,7 @@ static inline enum err plaintext_encrypt(struct context *c,
 					 uint8_t *out_ciphertext,
 					 uint32_t out_ciphertext_len)
 {
-	return cose_encrypt(in_plaintext, out_ciphertext, out_ciphertext_len,
+	return oscore_cose_encrypt(in_plaintext, out_ciphertext, out_ciphertext_len,
 			    &c->rrc.nonce, &c->rrc.aad, &c->sc.sender_key);
 }
 

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -149,7 +149,7 @@ static inline enum err payload_decrypt(struct context *c,
 		.len = oscore_packet->payload_len,
 		.ptr = oscore_packet->payload,
 	};
-	return cose_decrypt(&oscore_ciphertext, out_plaintext, &c->rrc.nonce,
+	return oscore_cose_decrypt(&oscore_ciphertext, out_plaintext, &c->rrc.nonce,
 			    &c->rrc.aad, &c->rc.recipient_key);
 }
 

--- a/src/oscore/oscore_coap.c
+++ b/src/oscore/oscore_coap.c
@@ -158,8 +158,8 @@ static inline enum err buf2options(uint8_t *in_data, uint16_t in_data_len,
 			temp_option_header_len =
 				(uint8_t)(temp_option_header_len + 2);
 			temp_option_delta =
-				(uint8_t)((*temp_options_ptr) << 8 |
-					  *(temp_options_ptr + 1) - 269);
+				(uint8_t)(((*temp_options_ptr) << 8) |
+					  (*(temp_options_ptr + 1) - 269));
 			temp_options_ptr += 2;
 			break;
 		case 15:
@@ -182,8 +182,8 @@ static inline enum err buf2options(uint8_t *in_data, uint16_t in_data_len,
 			temp_option_header_len =
 				(uint8_t)(temp_option_header_len + 2);
 			temp_option_len =
-				(uint8_t)((*temp_options_ptr) << 8 |
-					  *(temp_options_ptr + 1) + 269);
+				(uint8_t)(((*temp_options_ptr) << 8) |
+					  (*(temp_options_ptr + 1) + 269));
 			temp_options_ptr += 2;
 			break;
 		case 15:

--- a/src/oscore/oscore_cose.c
+++ b/src/oscore/oscore_cose.c
@@ -57,7 +57,7 @@ static enum err create_enc_structure(struct byte_array *external_aad,
 	return ok;
 }
 
-enum err cose_decrypt(struct byte_array *in_ciphertext,
+enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
 		      struct byte_array *out_plaintext,
 		      struct byte_array *nonce,
 		      struct byte_array *recipient_aad, struct byte_array *key)
@@ -88,7 +88,7 @@ enum err cose_decrypt(struct byte_array *in_ciphertext,
 	return ok;
 }
 
-enum err cose_encrypt(struct byte_array *in_plaintext, uint8_t *out_ciphertext,
+enum err oscore_cose_encrypt(struct byte_array *in_plaintext, uint8_t *out_ciphertext,
 		      uint32_t out_ciphertext_len, struct byte_array *nonce,
 		      struct byte_array *sender_aad, struct byte_array *key)
 {


### PR DESCRIPTION
Functions of generic name `cose_encrypt()' or `cose_decrypt()' used by OSCORE lib make naming collisions if there is in the system generic COSE library.