### PR TITLE
Add pointers validation before memcpy operation

### DIFF
--- a/src/common/memcpy_s.c
+++ b/src/common/memcpy_s.c
@@ -27,6 +27,11 @@ enum err check_buffer_size(uint32_t is_size, uint32_t required_size)
 enum err _memcpy_s(uint8_t *dest, uint32_t dest_len, const uint8_t *source,
 		   uint32_t source_len)
 {
+	if ((NULL == dest) || (NULL == source))
+	{
+		return wrong_parameter;
+	}
+
 	TRY(check_buffer_size(dest_len, source_len));
 	memcpy(dest, source, source_len);
 	return ok;


### PR DESCRIPTION
memcpy function shouldn't be run on NULL pointers. Added validation crashes tests because test vectors includes sender_id or id_context set to NULL. If tests vectors force us to handle NULL pointers of these arguments we can:
1. Return ok after check and do not perform memcpy, set dest pointer to NULL and exit with ok exit code. I don't like to return ok if the operation can be done properly (NULL pointers)
2. Use special TRY_MEMCPY macro to validate the result with proper handling of wrong_parameter error code.

@StefanHri  what do you think?