### PR TITLE
Allow the repository to be integrated as a Zephyr module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: uoscore-uedhoc
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Zephyr expects that every module has a zephyr/module.yml file, which specifies where to look for a module specific 
CMakeLists.txt and Kconfig files.

As for Today, this is the only change needed in the uoscore-uedhoc repository in order to make it a Zephyr module. I figured it'd be nice to keep the module.yml in the orignal repository, it's no harm for non-zephyr users, and this allows to maintain one-to-one repostiory copy for Zephyr, w/o downstream patches.

The current state of integration can be viewed at https://github.com/rlubos/zephyr/tree/oscore-test. The test within Zephyr repository make use of zcbor and mbed TLS hosted by Zephyr (hence multiple minor patches towards mbed TLS integration). The only submodule remaining being in use is c25519, I'm still struggling with it.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>