### PR TITLE
More robust implementation of replay window, added tests

### DIFF
--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -62,6 +62,7 @@ enum err {
 	delta_extra_byte_error = 215,
 	len_extra_byte_error = 216,
 	not_valid_input_packet = 218,
+	oscore_replay_window_protection_error = 219,
 
 };
 

--- a/inc/oscore/replay_protection.h
+++ b/inc/oscore/replay_protection.h
@@ -5,36 +5,70 @@
 #include <stdbool.h>
 #include "common/oscore_edhoc_error.h"
 
+/* Replay window size - it can be defined by the user here or outside of this file. */
+/* NOTE: window size of 32 is the MINUMUM that is RFC-compliant. */
+#ifndef OSCORE_SERVER_REPLAY_WINDOW_SIZE
+#define OSCORE_SERVER_REPLAY_WINDOW_SIZE 32
+#endif
+
+/* Replay window structure, used internally. */
+typedef struct {
+	uint64_t window[OSCORE_SERVER_REPLAY_WINDOW_SIZE];
+	bool seq_num_zero_received; /* helper flag used for validation of sequence number 0 */
+} server_replay_window_t;
+
 /**
  * @brief Initialize given replay window with default values.
  *
- * @param replay_window [out] a pointer to replay window
- * @param replay_window_len [in] elements count of replay window
+ * @param replay_window [out] a pointer to replay window structure
  * @return err
  */
-enum err server_replay_window_init(uint64_t *replay_window,
-				   uint8_t replay_window_len);
+enum err server_replay_window_init(server_replay_window_t *replay_window);
+
+/**
+ * @brief Re-initialize given replay window based on current sequence number.
+ *
+ * This could be used by the user to restore the session.
+ * After restoring, replay protection will reject any packet with sequence number
+ * that is not greater than the one provided in the argument.
+ *
+ * @param current_sequence_number [in] last sequence number that was received before the session was stored
+ * @param replay_window [out] a pointer to replay window structure
+ * @return err
+ */
+enum err server_replay_window_reinit(uint64_t current_sequence_number,
+				     server_replay_window_t *replay_window);
+
+/**
+ * @brief Get currently newest sequence number from the replay window.
+ *
+ * This could be used by the user to store the session.
+ *
+ * @param seq_number [out] a pointer where result will be stored
+ * @param replay_window [in] a pointer to replay window structure
+ * @return err
+ */
+enum err server_replay_window_get_last_number(
+	uint64_t *seq_number, const server_replay_window_t *replay_window);
 
 /**
  * @brief Check whether given sequence number is valid in terms of server replay protection.
  *
  * @param seq_number [in] sequence number of the message received by the server
- * @param replay_window [in] a pointer to replay window
- * @param replay_window_len [in] elements count of replay window
+ * @param replay_window [in] a pointer to replay window structure
  * @return true if ok, false otherwise
  */
 bool server_is_sequence_number_valid(uint64_t seq_number,
-				     uint64_t *replay_window,
-				     uint8_t replay_window_len);
+				     server_replay_window_t *replay_window);
 
 /**
  * @brief Update given replay window with last received sequence number.
  *
  * @param seq_number [in] sequence number of the message received by the server
- * @param replay_window [out] a pointer to replay window
- * @param replay_window_len [in] elements count of replay window
+ * @param replay_window [out] a pointer to replay window structure
+ * @return true if ok, false if sequence number is not valid (this indicates that calling function hasn't check the sequence number before)
  */
-void server_replay_window_update(uint64_t seq_number, uint64_t *replay_window,
-				 uint8_t replay_window_len);
+bool server_replay_window_update(uint64_t seq_number,
+				 server_replay_window_t *replay_window);
 
 #endif

--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -14,11 +14,10 @@
 
 #include "supported_algorithm.h"
 #include "oscore_coap.h"
+#include "oscore/replay_protection.h"
 
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
-
-#define REPLAY_WINDOW_LEN 32
 
 enum dev_type {
 	SERVER,
@@ -59,8 +58,7 @@ struct recipient_context {
 	struct byte_array recipient_key;
 	uint8_t recipient_key_buf[RECIPIENT_KEY_LEN_];
 	uint8_t recipient_id_buf[RECIPIENT_ID_BUFF_LEN];
-	uint64_t replay_window[REPLAY_WINDOW_LEN];
-	uint8_t replay_window_len;
+	server_replay_window_t replay_window;
 };
 
 /*request-response context contains parameters that need to persists between

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -532,11 +532,12 @@ enum err oscore2coap(uint8_t *buf_in, uint32_t buf_in_len, uint8_t *buf_out,
 			}
 
 			/*check is the packet is replayed*/
-			TRY_EXPECT(server_is_sequence_number_valid(
+			if(!server_is_sequence_number_valid(
 					   *oscore_option.piv.ptr,
-					   c->rc.replay_window,
-					   c->rc.replay_window_len),
-				   true);
+					   &c->rc.replay_window))
+			{
+			    return oscore_replay_window_protection_error;
+			}
 
 			/*If this is a request message we need to calculate the nonce, aad 
             and eventually update the Common IV, Sender and Recipient Keys*/
@@ -564,8 +565,7 @@ enum err oscore2coap(uint8_t *buf_in, uint32_t buf_in_len, uint8_t *buf_out,
 			if (is_request(&oscore_packet)) {
 				server_replay_window_update(
 					*oscore_option.piv.ptr,
-					c->rc.replay_window,
-					c->rc.replay_window_len);
+					&c->rc.replay_window);
 			}
 		} else {
 			return r;

--- a/src/oscore/replay_protection.c
+++ b/src/oscore/replay_protection.c
@@ -3,6 +3,8 @@
 
 #include "oscore/replay_protection.h"
 
+#define WINDOW_SIZE OSCORE_SERVER_REPLAY_WINDOW_SIZE
+
 /**
  * @brief Insert given sequence number in the specified position of replay window.
 
@@ -11,48 +13,89 @@
  * @param position [in] index to place new number (all older elements will be left-shifted)
  */
 static void server_replay_window_insert(uint64_t seq_number,
-					uint64_t *replay_window,
-					uint8_t position)
+					server_replay_window_t *replay_window,
+					size_t position)
 {
+	uint64_t *window = replay_window->window;
+
 	/*shift all old values one position to the left*/
-	size_t shift_length = position * sizeof(replay_window[0]);
-	memmove(replay_window, replay_window + 1, shift_length);
+	size_t shift_length = position * sizeof(window[0]);
+	memmove(window, window + 1, shift_length);
 
 	/*insert the new sender sequence number at a given position*/
-	replay_window[position] = seq_number;
+	window[position] = seq_number;
 }
 
-enum err server_replay_window_init(uint64_t *replay_window,
-				   uint8_t replay_window_len)
+enum err server_replay_window_init(server_replay_window_t *replay_window)
 {
-	if ((NULL == replay_window) || (0 == replay_window_len)) {
+	if (NULL == replay_window) {
 		return wrong_parameter;
 	}
 
-	memset(replay_window, 0, replay_window_len * sizeof(replay_window[0]));
+	memset(replay_window->window, 0, WINDOW_SIZE * sizeof(replay_window->window[0]));
+	replay_window->seq_num_zero_received = false;
+	return ok;
+}
+
+enum err server_replay_window_reinit(uint64_t current_sequence_number,
+				     server_replay_window_t *replay_window)
+{
+	if (NULL == replay_window) {
+		return wrong_parameter;
+	}
+
+	/*fill the window in a way that only new sequence numbers are accepted*/
+	for (uint8_t j = 0; j < WINDOW_SIZE; j++) {
+		replay_window->window[(WINDOW_SIZE - 1) - j] =
+			current_sequence_number;
+		if (current_sequence_number > 0) {
+			current_sequence_number--;
+		}
+	}
+
+	/* don't accept seqNum=0 anymore */
+	replay_window->seq_num_zero_received = true;
+
+	return ok;
+}
+
+enum err server_replay_window_get_last_number(
+	uint64_t *seq_number, const server_replay_window_t *replay_window)
+{
+	if ((NULL == replay_window) || (NULL == seq_number)) {
+		return wrong_parameter;
+	}
+
+	*seq_number = replay_window->window[WINDOW_SIZE - 1];
 	return ok;
 }
 
 bool server_is_sequence_number_valid(uint64_t seq_number,
-				     uint64_t *replay_window,
-				     uint8_t replay_window_len)
+				     server_replay_window_t *replay_window)
 {
-	/*if the sender sequence number is bigger than the
-    right most element -> all good */
-	if (seq_number > replay_window[replay_window_len - 1]) {
-		return true;
-	}
-
-	/*if the sender sequence number is smaller than the
-    left most element -> a replay is detected*/
-	if (seq_number < replay_window[0]) {
+	if (NULL == replay_window) {
 		return false;
 	}
 
-	/*if the sender sequence number is in the replay window
-    -> a replay is detected*/
-	for (uint8_t i = 0; i < replay_window_len; i++) {
-		if (seq_number == replay_window[i]) {
+	/* replay window uses zeros for unused entries, so in case of sequence number is 0, a little logic is needed */
+	if (0 == seq_number) {
+		if ((!replay_window->seq_num_zero_received) && (0 == replay_window->window[0]))
+		{
+			return true;
+		}
+		return false;
+	}
+
+	if (seq_number > replay_window->window[WINDOW_SIZE - 1]) {
+		return true;
+	}
+
+	if (seq_number < replay_window->window[0]) {
+		return false;
+	}
+
+	for (uint8_t i = 0; i < WINDOW_SIZE; i++) {
+		if (seq_number == replay_window->window[i]) {
 			return false;
 		}
 	}
@@ -60,15 +103,29 @@ bool server_is_sequence_number_valid(uint64_t seq_number,
 	return true;
 }
 
-void server_replay_window_update(uint64_t seq_number, uint64_t *replay_window,
-				 uint8_t replay_window_len)
+bool server_replay_window_update(uint64_t seq_number,
+				 server_replay_window_t *replay_window)
 {
+	/* Although sequence number should be checked before by the calling function, do it again to prevent possible security issues in case it was not. */
+	bool is_valid =
+		server_is_sequence_number_valid(seq_number, replay_window);
+	if (!is_valid) {
+		return false;
+	}
+
+	if (seq_number == 0) {
+		replay_window->seq_num_zero_received = true;
+		return true;
+	}
+
 	uint16_t index;
-	for (index = 0; index < replay_window_len - 1; index++) {
-		if ((replay_window[index] < seq_number) &&
-		    (replay_window[index + 1] > seq_number)) {
+	for (index = 0; index < WINDOW_SIZE - 1; index++) {
+		/* when the loop doesn't find proper index to place the number, it will stop at index = WINDOW_SIZE-1 */
+		if ((replay_window->window[index] < seq_number) &&
+		    (replay_window->window[index + 1] > seq_number)) {
 			break;
 		}
 	}
 	server_replay_window_insert(seq_number, replay_window, index);
+	return true;
 }

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -187,9 +187,7 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	TRY(derive_common_iv(&c->cc));
 
 	/*derive Recipient Context*********************************************/
-	c->rc.replay_window_len = REPLAY_WINDOW_LEN;
-	memset(c->rc.replay_window, 0,
-	       sizeof(c->rc.replay_window[0]) * c->rc.replay_window_len);
+	server_replay_window_init(&c->rc.replay_window);
 	c->rc.recipient_id.len = params->recipient_id.len;
 	c->rc.recipient_id.ptr = c->rc.recipient_id_buf;
 	memcpy(c->rc.recipient_id.ptr, params->recipient_id.ptr, params->recipient_id.len);


### PR DESCRIPTION
Changes:
- fixed replay window implementation to work properly with zero sequence number
- refactored tests and added edge cases tests
- added functions for re-initialization of replay window based on last received sequence number, and reading that number from the window - this can be used by the user to virtually store the replay window in non-volatile memory.
- added support for 4.01 (Unauthorized) error code when replay verification fails 