### PR TITLE
Superfluous checks

### DIFF
--- a/src/edhoc/responder.c
+++ b/src/edhoc/responder.c
@@ -178,7 +178,7 @@ static inline enum err msg2_encode(const uint8_t *g_y, uint32_t g_y_len,
 
 	/*Encode C_R*/
 	PRINT_ARRAY("C_R", c_r, c_r_len);
-	if (c_r_len == 1 && ((0x00 <= c_r[0] && c_r[0] < 0x18) ||
+	if (c_r_len == 1 && (c_r[0] < 0x18 ||
 			     (0x1F < c_r[0] && c_r[0] <= 0x37))) {
 		m._m2_C_R_choice = _m2_C_R_int;
 		TRY(decode_int(c_r, 1, &m._m2_C_R_int));

--- a/src/edhoc/th.c
+++ b/src/edhoc/th.c
@@ -53,7 +53,7 @@ static inline enum err th2_input_encode(uint8_t *hash_msg1,
 	th2._th2_G_Y.len = g_y_len;
 
 	/*Encode C_R as int or byte*/
-	if (c_r_len == 1 && ((0x00 <= c_r[0] && c_r[0] < 0x18) ||
+	if (c_r_len == 1 && (c_r[0] < 0x18 ||
 			     (0x1F < c_r[0] && c_r[0] <= 0x37))) {
 		th2._th2_C_R_choice = _th2_C_R_int;
 		TRY(decode_int(c_r, 1, &th2._th2_C_R_int));


### PR DESCRIPTION
Our cross-compiler compiler (gcc-arm-none-eabi-10.3-2021.10) complains about extra checks
```
src/edhoc/responder.c:181:29: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  181 |  if (c_r_len == 1 && ((0x00 <= c_r[0] && c_r[0] < 0x18) ||
```
since c_r[0] is unsigned char, such check (0x00 <= c_r[0]) makes no sense.
