### PR TITLE
Encryption/decryption flow refactor and bugfixes

### DIFF
--- a/inc/common/byte_array.h
+++ b/inc/common/byte_array.h
@@ -42,7 +42,7 @@ extern struct byte_array NULL_ARRAY;
 bool array_equals(const struct byte_array *left,
 		  const struct byte_array *right);
 
-enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src);
+enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src, const size_t dest_max_len);
 
 /**
  * @brief   Sets the pointer and the length of a byte_array variable to a given array

--- a/src/common/byte_array.c
+++ b/src/common/byte_array.c
@@ -25,9 +25,9 @@ struct byte_array NULL_ARRAY = {
 };
 
 
-enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src)
+enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src, const size_t dest_max_len)
 {
-	TRY(_memcpy_s(dest->ptr, dest->len, src->ptr, src->len));
+	TRY(_memcpy_s(dest->ptr, dest_max_len, src->ptr, src->len));
 	dest->len = src->len;
 	return ok;
 }

--- a/src/oscore/nvm.c
+++ b/src/oscore/nvm.c
@@ -18,14 +18,14 @@
 enum err WEAK nvm_write_ssn(const struct byte_array *sender_id,
 			    const struct byte_array *id_context, uint64_t ssn)
 {
-	PRINTF("The nvm_write_ssn() function MUST be overwritten by user!!!\n");
+	PRINT_MSG("The nvm_write_ssn() function MUST be overwritten by user!!!\n");
 	return not_implemented;
 }
 
 enum err WEAK nvm_read_ssn(const struct byte_array *sender_id,
 			   const struct byte_array *id_context, uint64_t *ssn)
 {
-	PRINTF("The nvm_read_ssn() function MUST be overwritten by user!!!\n");
+	PRINT_MSG("The nvm_read_ssn() function MUST be overwritten by user!!!\n");
 	*ssn = 0;
 	return not_implemented;
 }

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -184,8 +184,8 @@ enum err update_request_piv_request_kid(struct context *c,
 					struct byte_array *piv,
 					struct byte_array *kid)
 {
-	TRY(byte_array_cpy(&c->rrc.request_kid, kid));
-	TRY(byte_array_cpy(&c->rrc.request_piv, piv));
+	TRY(byte_array_cpy(&c->rrc.request_kid, kid, MAX_KID_LEN));
+	TRY(byte_array_cpy(&c->rrc.request_piv, piv, MAX_PIV_LEN));
 	return ok;
 }
 

--- a/test/mocks/nvm.c
+++ b/test/mocks/nvm.c
@@ -6,7 +6,7 @@ enum err nvm_write_ssn(const struct byte_array *sender_id,
     (void)sender_id;
     (void)id_context;
     (void)ssn;
-    PRINTF("NVM write mock\n");
+    PRINT_MSG("NVM write mock\n");
     return ok;
 }
 
@@ -15,7 +15,7 @@ enum err nvm_read_ssn(const struct byte_array *sender_id,
 {
     (void)sender_id;
     (void)id_context;
-    PRINTF("NVM read mock\n");
+    PRINT_MSG("NVM read mock\n");
     *ssn = 0;
     return ok;
 }


### PR DESCRIPTION
A proposal for new approach to encryption/decryption flow. In my opinion it is much easier to read and follow the RFC spec.

- simplified encryption and decryption flow for every scenario by introducing dedicated wrappers
- request-response context fields are now updated only after successful operation
- fixed bug in byte_array_cpy (destination buffer might be understood as too short just because it has short value assigned, regardless of its actual allocated size)
- resolved NVM print warnings