### PR TITLE
fixed the startup flow for wrong echo in the request

### DIFF
--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -25,6 +25,15 @@ enum derive_type {
 };
 
 /**
+ * @brief State machine for replay window synchronization using ECHO option after server reboot.
+ */
+enum echo_state {
+	ECHO_REBOOT, /* default value after reboot */
+	ECHO_VERIFY, /* verification in progress */
+	ECHO_SYNCHRONIZED, /* synchronized, normal operation */
+};
+
+/**
  * @brief Common Context
  * Contains information common to the Sender and Recipient Contexts
  */
@@ -75,10 +84,9 @@ struct req_resp_context {
 	uint8_t echo_opt_val_buf[ECHO_OPT_VALUE_LEN];
 
 	struct byte_array token_request;
-	uint8_t token_request_bug[MAX_TOKEN_LEN];
+	uint8_t token_request_buf[MAX_TOKEN_LEN];
 
-	bool reboot;
-	bool second_req_expected;
+	enum echo_state echo_state_machine;
 };
 
 /* Context struct containing all contexts*/

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -612,8 +612,8 @@ enum err coap2oscore(uint8_t *buf_o_coap, uint32_t buf_o_coap_len,
 					o_coap_pkt.header.TKL,
 					o_coap_pkt.token));
 
-	} else if (c->rrc.second_req_expected) {
-		/* A server prepares a response to first request after reboot.*/
+	} else if (ECHO_VERIFY == c->rrc.echo_state_machine) {
+		/* A server prepares a response with ECHO challenge after the reboot.*/
 		TRY(cache_echo_val(&c->rrc.echo_opt_val, e_options,
 				   e_options_cnt));
 

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -402,7 +402,7 @@ enum err oscore2coap(uint8_t *buf_in, uint32_t buf_in_len, uint8_t *buf_out,
 					&oscore_option.piv));
 			} else {
 				/*Notification without PIV received -- Currently not supported*/
-				return not_supported_feature;
+				return not_supported_feature; //LCOV_EXCL_LINE
 			}
 		} else {
 			/*regular response received*/

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -154,10 +154,9 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	c->rrc.request_piv.ptr = c->rrc.request_piv_buf;
 	c->rrc.echo_opt_val.len = sizeof(c->rrc.echo_opt_val_buf);
 	c->rrc.echo_opt_val.ptr = c->rrc.echo_opt_val_buf;
-	c->rrc.token_request.len = sizeof(c->rrc.token_request_bug);
-	c->rrc.token_request.ptr = c->rrc.token_request_bug;
-	c->rrc.reboot = true;
-	c->rrc.second_req_expected = false;
+	c->rrc.token_request.len = sizeof(c->rrc.token_request_buf);
+	c->rrc.token_request.ptr = c->rrc.token_request_buf;
+	c->rrc.echo_state_machine = ECHO_REBOOT;
 	return ok;
 }
 

--- a/test/oscore_integration_tests/oscore_integration_tests.c
+++ b/test/oscore_integration_tests/oscore_integration_tests.c
@@ -208,7 +208,7 @@ void t2_oscore_server_request_response(void)
 	zassert_equal(r, ok, "Error in oscore_context_init");
 
 	/*we test here the regular behavior not the behaviour after reboot*/
-	c_server.rrc.reboot = false;
+	c_server.rrc.echo_state_machine = ECHO_SYNCHRONIZED;
 
 	/*Test decrypting of an incoming request*/
 	uint8_t buf_coap[256];
@@ -426,7 +426,7 @@ void t9_oscore_client_server_observe(void)
 	r = oscore_context_init(&params_server, &c_server);
 	zassert_equal(r, ok, "Error in oscore_context_init for server");
 	/*we test the general case not the case after reboot*/
-	c_server.rrc.reboot = false;
+	c_server.rrc.echo_state_machine = ECHO_SYNCHRONIZED;
 
 	/*
 	 *

--- a/test/oscore_unit_tests/unit_test_replay_protection.c
+++ b/test/oscore_unit_tests/unit_test_replay_protection.c
@@ -71,6 +71,9 @@ void t600_server_replay_init_test(void)
 	result = server_replay_window_init(&replay_window);
 	zassert_equal(ok, result, "");
 	_compare_windows(&replay_window, &compare_window);
+
+	/* extra check of helper function */
+	zassert_equal(false, server_is_sequence_number_valid(0, NULL), "");
 }
 
 /**


### PR DESCRIPTION
With current implementation, in case of wrong value of the ECHO option in the second request, the whole flow is blocked until the device is rebooted. A state machine was introduced to properly handle it.

The solution was unit tested locally on commit 0005fc7c4d52d1799259da3cc4c39c15166539e4, as last merges introduced errors in EDHOC responder.