### PR TITLE
fix: added necessary NVM write after reboot

### DIFF
--- a/src/oscore/nvm.c
+++ b/src/oscore/nvm.c
@@ -54,6 +54,9 @@ enum err ssn_init(const struct byte_array *sender_id,
 	} else {
 		TRY(nvm_read_ssn(sender_id, id_context, ssn));
 		*ssn += K_SSN_NVM_STORE_INTERVAL + F_NVM_MAX_WRITE_FAILURE;
+
+		/* Updated SSN has to be written back immediately, in case of uncontrolled reboot before first write happens. */
+		TRY(nvm_write_ssn(sender_id, id_context, ssn));
 		PRINTF("SSN initialized from NMV. SSN = %" PRIu64 "\n", *ssn);
 	}
 	return ok;


### PR DESCRIPTION
Additional NVM write has to be added for proper operation described in https://datatracker.ietf.org/doc/html/rfc8613#section-7.5:
```
If an endpoint makes use of a partial security
context stored in nonvolatile memory, it MUST NOT reuse a
previous Sender Sequence Number and MUST NOT accept previously
received messages.
```

This requirement is not met now if the device reboots before first NVM write (once per x SSN increments).