### PR TITLE
fixed piv encoding and decoding

### DIFF
--- a/inc/oscore/oscore_coap.h
+++ b/inc/oscore/oscore_coap.h
@@ -24,6 +24,7 @@
 #define MAX_KID_LEN 8
 #define MAX_AAD_LEN 30
 #define MAX_INFO_LEN 50
+#define MAX_SSN_VALUE 0xFFFFFFFFFF /* maximum SSN value is 2^40-1, according to RFC 8613 p. 7.2.1.*/
 
 /* Mask and offset for first byte in CoAP/OSCORE header*/
 #define HEADER_LEN 4

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -110,10 +110,9 @@ STATIC enum err oscore_option_parser(const struct o_coap_option *opt,
 					out->kid_context.len = *val_ptr;
 					out->kid_context.ptr = ++val_ptr;
 					val_ptr += out->kid_context.len;
-					temp_kid_len =
-						(uint8_t)(temp_kid_len -
-							  (out->kid_context.len +
-							   1));
+					temp_kid_len = (uint8_t)(
+						temp_kid_len -
+						(out->kid_context.len + 1));
 				}
 
 				/* Get KID */
@@ -334,9 +333,10 @@ enum err oscore2coap(uint8_t *buf_in, uint32_t buf_in_len, uint8_t *buf_out,
 		/* Check if the packet is replayed - in case of normal operation (replay window already synchronized).
 		   It must be performed before decrypting the packet (see RFC 8613 p. 7.4). */
 		if (ECHO_SYNCHRONIZED == c->rrc.echo_state_machine) {
+			uint64_t ssn;
+			piv2ssn(&oscore_option.piv, &ssn);
 			if (!server_is_sequence_number_valid(
-				    *oscore_option.piv.ptr,
-				    &c->rc.replay_window)) {
+				    ssn, &c->rc.replay_window)) {
 				PRINT_MSG("Replayed message detected!\n");
 				return oscore_replay_window_protection_error;
 			}

--- a/test/main.c
+++ b/test/main.c
@@ -173,6 +173,7 @@ void test_main(void)
 		ztest_unit_test(t402_echo_val_is_fresh),
 		ztest_unit_test(t500_oscore_context_init_corner_cases),
 		ztest_unit_test(t501_piv2ssn),
+		ztest_unit_test(t502_ssn2piv),
 		ztest_unit_test(t503_derive_corner_case),
 		ztest_unit_test(t600_server_replay_init_test),
 		ztest_unit_test(t601_server_replay_reinit_test),

--- a/test/oscore_tests.h
+++ b/test/oscore_tests.h
@@ -46,7 +46,7 @@ void t402_echo_val_is_fresh(void);
 
 void t500_oscore_context_init_corner_cases(void);
 void t501_piv2ssn(void);
-void t502_verify_token(void);
+void t502_ssn2piv(void);
 void t503_derive_corner_case(void);
 
 void t600_server_replay_init_test(void);


### PR DESCRIPTION
- Replay protection was using raw PIV buffer instead of SSN value
- Encoding and decoding between SSN and PIV was performed in little endian, but should be in network byte order (big endian)

The two above resulted in wrong behavior while using aiocoap as a client, and uoscore as a server (after PIV=0xFF, receiving PIV=0x0100 was read by the server as 0x00, which resulted in replay error).

Also, added extensive tests for ssn <-> piv conversion functions.