### PR TITLE
feat: updated NVM storage interface and storing logic

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -138,33 +138,26 @@ AES keys should never be used more than once with a given nonce, see [RFC5084](h
    * `fresh_master_secret_salt = false` in case the same master secret and salt are used in subsequent reboots. In this case the user should implement in addition two functions that require access to Non-volatile Memory (NVM):
    ```c
    /**
-   * @brief   When the same OSCORE master secret and salt are reused through
-   * 			several reboots of the device, e.g., no fresh shared secret is
-   * 			derived through EDHOC (or some other method) the Sender Sequence 
-   * 			Number MUST be stored periodically in NVM. 
-   * @param	sender_id the user may use the sender_id as a key in a table in 
-   * 			NVM holding SSNs for different sender contexts. 
-   * @param   id_context id of the context. To be used as an additional key 
-   * @param	ssn the ssn to be written in NVM
-   * @retval	ok or error code if storing the SSN was not possible.
+   * @brief When the same OSCORE master secret and salt are reused through
+   *        several reboots of the device, e.g., no fresh shared secret is
+   *        derived through EDHOC (or some other method) the Sender Sequence 
+   *        Number MUST be stored periodically in NVM. 
+   * @param nvm_key part of the context that is permitted to be used for identifying the right store slot in NVM.
+   * @param	ssn SSN to be written in NVM.
+   * @retval ok or error code if storing the SSN was not possible.
    */
-   enum err nvm_write_ssn(const struct byte_array *sender_id,
-               const struct byte_array *id_context, uint64_t ssn)
-
+   enum err nvm_write_ssn(const struct nvm_key_t *nvm_key, uint64_t ssn);
 
    /**
-   * @brief   When the same OSCORE master secret and salt are reused through
-   * 			several reboots of the device, e.g., no fresh shared secret is
-   * 			derived through EDHOC (or some other method) the Sender Sequence 
-   * 			Number MUST be restored from NVM at each reboot. 
-   * @param	sender_id the user may use the sender_id as a key in a table in 
-   * 			NVM holding SSNs for different sender contexts. 
-   * @param   id_context id of the context. To be used as an additional key 
-   * @param	ssn the ssn to be read out from NVM
-   * @retval	ok or error code if the retrieving the SSN was not possible.
+   * @brief When the same OSCORE master secret and salt are reused through
+   *        several reboots of the device, e.g., no fresh shared secret is
+   *        derived through EDHOC (or some other method) the Sender Sequence 
+   *        Number MUST be restored from NVM at each reboot. 
+   * @param nvm_key part of the context that is permitted to be used for identifying the right store slot in NVM.
+   * @param	ssn SSN to be read out from NVM.
+   * @retval ok or error code if the retrieving the SSN was not possible.
    */
-   enum err nvm_read_ssn(const struct byte_array *sender_id,
-               const struct byte_array *id_context, uint64_t *ssn)
+   enum err nvm_read_ssn(const struct nvm_key_t *nvm_key, uint64_t *ssn);
    ```  
 
 ## Additional configuration options

--- a/inc/common/byte_array.h
+++ b/inc/common/byte_array.h
@@ -48,7 +48,7 @@ enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src,
 /**
  * @brief   Sets the pointer and the length of a byte_array variable to a given array
 */
-#define BYTE_ARRAY_INIT(PTR, SIZE) { .ptr = PTR, .len = SIZE };
+#define BYTE_ARRAY_INIT(PTR, SIZE) { .ptr = PTR, .len = SIZE }
 
 /**
  * @brief   Creates a variable of type byte_array.

--- a/src/oscore/nvm.c
+++ b/src/oscore/nvm.c
@@ -16,47 +16,51 @@
 #include "common/oscore_edhoc_error.h"
 #include "common/print_util.h"
 
-enum err WEAK nvm_write_ssn(const struct byte_array *sender_id,
-			    const struct byte_array *id_context, uint64_t ssn)
+enum err WEAK nvm_write_ssn(const struct nvm_key_t *nvm_key, uint64_t ssn)
 {
 	PRINT_MSG(
 		"The nvm_write_ssn() function MUST be overwritten by user!!!\n");
 	return not_implemented;
 }
 
-enum err WEAK nvm_read_ssn(const struct byte_array *sender_id,
-			   const struct byte_array *id_context, uint64_t *ssn)
+enum err WEAK nvm_read_ssn(const struct nvm_key_t *nvm_key, uint64_t *ssn)
 {
 	PRINT_MSG(
 		"The nvm_read_ssn() function MUST be overwritten by user!!!\n");
-	*ssn = 0;
+	if (NULL != ssn) {
+		*ssn = 0;
+	}
 	return not_implemented;
 }
 
-enum err ssn_store_in_nvm(const struct byte_array *sender_id,
-			  const struct byte_array *id_context, uint64_t ssn,
-			  bool ssn_in_nvm)
+enum err ssn_store_in_nvm(const struct nvm_key_t *nvm_key, uint64_t ssn,
+			  bool is_storable, bool echo_sync_in_progress)
 {
-	if ((0 == ssn % K_SSN_NVM_STORE_INTERVAL) && ssn_in_nvm) {
-		TRY(nvm_write_ssn(sender_id, id_context, ssn));
+	bool cyclic_write = (0 == ssn % K_SSN_NVM_STORE_INTERVAL);
+
+	/* While the device is still in the ECHO synchronization mode (after device reboot or other context reinitialization)
+	   SSN has to be written immediately, in case of uncontrolled reboot before first cyclic write happens. */
+	if (is_storable && (cyclic_write || echo_sync_in_progress)) {
+		TRY(nvm_write_ssn(nvm_key, ssn));
 	}
 	return ok;
 }
 
-enum err ssn_init(const struct byte_array *sender_id,
-		  const struct byte_array *id_context, uint64_t *ssn,
-		  bool ssn_in_nvm)
+enum err ssn_init(const struct nvm_key_t *nvm_key, uint64_t *ssn,
+		  bool is_storable)
 {
-	if (!ssn_in_nvm) {
+	if ((NULL == nvm_key) || (NULL == ssn)) {
+		return wrong_parameter;
+	}
+
+	if (!is_storable) {
 		*ssn = 0;
-		PRINTF("SSN initialized not from NMV. SSN = %" PRIu64 "\n",
+		PRINTF("Security context is not storable, SSN initialized to %" PRIu64
+		       "\n",
 		       *ssn);
 	} else {
-		TRY(nvm_read_ssn(sender_id, id_context, ssn));
+		TRY(nvm_read_ssn(nvm_key, ssn));
 		*ssn += K_SSN_NVM_STORE_INTERVAL + F_NVM_MAX_WRITE_FAILURE;
-
-		/* Updated SSN has to be written back immediately, in case of uncontrolled reboot before first write happens. */
-		TRY(nvm_write_ssn(sender_id, id_context, *ssn));
 		PRINTF("SSN initialized from NMV. SSN = %" PRIu64 "\n", *ssn);
 	}
 	return ok;

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -141,8 +141,12 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	c->sc.sender_key.len = sizeof(c->sc.sender_key_buf);
 	c->sc.sender_key.ptr = c->sc.sender_key_buf;
 	c->sc.ssn_in_nvm = !params->fresh_master_secret_salt;
-	TRY(ssn_init(&c->sc.sender_id, &c->cc.id_context, &c->sc.ssn,
-		     c->sc.ssn_in_nvm));
+	struct nvm_key_t nvm_key = {
+		.sender_id = c->sc.sender_id,
+		.recipient_id = c->rc.recipient_id,
+		.id_context = c->cc.id_context
+	};
+	TRY(ssn_init(&nvm_key, &c->sc.ssn, c->sc.ssn_in_nvm));
 	TRY(derive_sender_key(&c->cc, &c->sc));
 
 	/*set up the request response context**********************************/

--- a/test/mocks/nvm.c
+++ b/test/mocks/nvm.c
@@ -1,21 +1,17 @@
 #include "oscore.h"
 
-enum err nvm_write_ssn(const struct byte_array *sender_id,
-			    const struct byte_array *id_context, uint64_t ssn)
+enum err nvm_write_ssn(const struct nvm_key_t *nvm_key, uint64_t ssn)
 {
-    (void)sender_id;
-    (void)id_context;
-    (void)ssn;
-    PRINT_MSG("NVM write mock\n");
-    return ok;
+	(void)nvm_key;
+	(void)ssn;
+	PRINT_MSG("NVM write mock\n");
+	return ok;
 }
 
-enum err nvm_read_ssn(const struct byte_array *sender_id,
-			   const struct byte_array *id_context, uint64_t *ssn)
+enum err nvm_read_ssn(const struct nvm_key_t *nvm_key, uint64_t *ssn)
 {
-    (void)sender_id;
-    (void)id_context;
-    PRINT_MSG("NVM read mock\n");
-    *ssn = 0;
-    return ok;
+	(void)nvm_key;
+	PRINT_MSG("NVM read mock\n");
+	*ssn = 0;
+	return ok;
 }


### PR DESCRIPTION
- NVM functions interface were changed to give the user more values that can be used to determine the slot in NVM storage.
- instead of performing a write just after reading the SSN value at reboot, another condition was added inside `ssn_store_in_nvm` that supports writing the value after generating new nonce(s) while ECHO synchronization. It makes more sense and may simplify the user implementation, as there is no need to look for the slot that may not be existing yet (since context initialization is still not completed).