### PR TITLE
fixed wrong calculation of notification number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "_comment": "see https://travishorn.com/semantic-versioning-with-git-tags-1ef2d4aeede6   npm version patch, npm version minor, npm version major, git push --follow-tags",
     "name": "uoscore-uedhoc",
-    "version": "2.1.1"
+    "version": "2.1.2"
 }

--- a/src/oscore/replay_protection.c
+++ b/src/oscore/replay_protection.c
@@ -144,8 +144,7 @@ enum err notification_number_update(uint64_t *notification_num,
 				    bool *notification_num_initialized,
 				    struct byte_array *piv)
 {
-	TRY(_memcpy_s((uint8_t *)notification_num, sizeof(*notification_num),
-		      piv->ptr, piv->len));
+	TRY(piv2ssn(piv, notification_num));
 	*notification_num_initialized = true;
 	return ok;
 }


### PR DESCRIPTION
`notification_number_update` was using memcpy instead of dedicated PIV decoding function, resulting in falsely triggered notification check errors.