### PR TITLE
feat: added SSN overflow protection

### DIFF
--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -70,6 +70,7 @@ enum err {
 	oscore_replay_notification_protection_error = 216,
 	no_echo_option = 217,
 	echo_val_mismatch = 218,
+	oscore_ssn_overflow = 219,
 };
 
 /*This macro checks if a function returns an error and if so it propagates 

--- a/inc/oscore/oscore_coap.h
+++ b/inc/oscore/oscore_coap.h
@@ -24,7 +24,7 @@
 #define MAX_KID_LEN 8
 #define MAX_AAD_LEN 30
 #define MAX_INFO_LEN 50
-#define MAX_SSN_VALUE 0xFFFFFFFFFF /* maximum SSN value is 2^40-1, according to RFC 8613 p. 7.2.1.*/
+#define MAX_PIV_FIELD_VALUE 0xFFFFFFFFFF /* maximum possible value of SSN/PIV field is 2^40-1, according to RFC 8613 p. 7.2.1.*/
 
 /* Mask and offset for first byte in CoAP/OSCORE header*/
 #define HEADER_LEN 4

--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -19,6 +19,14 @@
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
 
+/* Upper limit of SSN that is allowed by AEAD algorithm (AES-CCM-16-64-128) is 2^23-1, according to RFC 9053 p. 4.2.1.
+   Exceeding this value results in constant 4.01 Unauthorized error, so new security context must be established.
+   Note that this value is lower than MAX_PIV_FIELD_VALUE, which only defines maximum value that is writable to the SSN/PIV field.
+*/
+#ifndef OSCORE_SSN_OVERFLOW_VALUE
+#define OSCORE_SSN_OVERFLOW_VALUE 0x7FFFFF
+#endif
+
 enum derive_type {
 	KEY,
 	IV,
@@ -120,6 +128,14 @@ enum err piv2ssn(struct byte_array *piv, uint64_t *ssn);
 enum err update_request_piv_request_kid(struct context *c,
 					struct byte_array *piv,
 					struct byte_array *kid);
+
+/**
+ * @brief Check if given security context is still safe to be used, or a new one must be established.
+ *        For more info, refer to RFC 8613 p. 7.2.1.
+ * @param c security context.
+ * @return enum err 
+ */
+enum err check_context_freshness(struct context *c);
 
 
 #endif

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -576,7 +576,10 @@ enum err coap2oscore(uint8_t *buf_o_coap, uint32_t buf_o_coap_len,
 	buf.len = buf_o_coap_len;
 	buf.ptr = buf_o_coap;
 
-	/*Parse the coap buf into a CoAP struct*/
+	/* Make sure that given context is fresh enough to process the message. */
+	TRY(check_context_freshness(c));
+
+	/* Parse the coap buf into a CoAP struct */
 	memset(&o_coap_pkt, 0, sizeof(o_coap_pkt));
 	TRY(coap_deserialize(&buf, &o_coap_pkt));
 

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -298,6 +298,9 @@ enum err oscore2coap(uint8_t *buf_in, uint32_t buf_in_len, uint8_t *buf_out,
 	buf.ptr = buf_in;
 	buf.len = buf_in_len;
 
+	/* Make sure that given context is fresh enough to process the message. */
+	TRY(check_context_freshness(c));
+
 	/*Parse the incoming message (buf_in) into a CoAP struct*/
 	memset(&oscore_packet, 0, sizeof(oscore_packet));
 	TRY(coap_deserialize(&buf, &oscore_packet));

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -171,9 +171,27 @@ enum err update_request_piv_request_kid(struct context *c,
 	return ok;
 }
 
+enum err check_context_freshness(struct context *c)
+{
+	if (NULL == c)
+	{
+		return wrong_parameter;
+	}
+
+	/* "If the Sender Sequence Number exceeds the maximum, the endpoint MUST NOT
+	   process any more messages with the given Sender Context."
+	   For more info, refer to RFC 8613 p. 7.2.1. */
+	if (c->sc.ssn >= OSCORE_SSN_OVERFLOW_VALUE )
+	{
+		PRINT_MSG("Sender Sequence Number reached its limit. New security context must be established.\n");
+		return oscore_ssn_overflow;
+	}
+	return ok;
+}
+
 enum err ssn2piv(uint64_t ssn, struct byte_array *piv)
 {
-	if ((NULL == piv) || (NULL == piv->ptr) || (ssn > MAX_SSN_VALUE)) {
+	if ((NULL == piv) || (NULL == piv->ptr) || (ssn > MAX_PIV_FIELD_VALUE)) {
 		return wrong_parameter;
 	}
 

--- a/test/main.c
+++ b/test/main.c
@@ -133,10 +133,6 @@ void test_main(void)
 		ztest_unit_test(test_initiator_responder_interaction2));
 
 	/* OSCORE test-vector tests */
-
-	// ztest_test_suite(
-	// 	oscore_tests,
-	// 	ztest_unit_test(t10_oscore_client_server_after_reboot));
 	ztest_test_suite(
 		oscore_tests,
 		ztest_unit_test(t1_oscore_client_request_response),
@@ -148,6 +144,7 @@ void test_main(void)
 		ztest_unit_test(t8_oscore_server_response_simple_ack),
 		ztest_unit_test(t9_oscore_client_server_observe),
 		ztest_unit_test(t10_oscore_client_server_after_reboot),
+		ztest_unit_test(t11_oscore_ssn_overflow_protection),
 		ztest_unit_test(
 			t100_inner_outer_option_split__no_special_options),
 		ztest_unit_test(
@@ -175,6 +172,7 @@ void test_main(void)
 		ztest_unit_test(t501_piv2ssn),
 		ztest_unit_test(t502_ssn2piv),
 		ztest_unit_test(t503_derive_corner_case),
+		ztest_unit_test(t504_context_freshness),
 		ztest_unit_test(t600_server_replay_init_test),
 		ztest_unit_test(t601_server_replay_reinit_test),
 		ztest_unit_test(t602_server_replay_check_at_start_test),

--- a/test/oscore_tests.h
+++ b/test/oscore_tests.h
@@ -21,6 +21,7 @@ void t6_oscore_server_key_derivation(void);
 void t8_oscore_server_response_simple_ack(void);
 void t9_oscore_client_server_observe(void);
 void t10_oscore_client_server_after_reboot(void);
+void t11_oscore_ssn_overflow_protection(void);
 
 /*unit tests*/
 void t100_inner_outer_option_split__no_special_options(void);
@@ -48,6 +49,7 @@ void t500_oscore_context_init_corner_cases(void);
 void t501_piv2ssn(void);
 void t502_ssn2piv(void);
 void t503_derive_corner_case(void);
+void t504_context_freshness(void);
 
 void t600_server_replay_init_test(void);
 void t601_server_replay_reinit_test(void);


### PR DESCRIPTION
Prior to this change, Sender Sequence Number could be increased endlessly, which would result in exceeding the maximum value that is writable into 5-byte PIV field.

In addition, further investigation has been made as to its maximum value for the supported AEAD algorithm (the suggested value is 2^23, not 2^40). Please refer to the comments for more information.