### PR TITLE
Feat: Added support for multiple OSCORE interactions

### DIFF
--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -71,6 +71,10 @@ enum err {
 	no_echo_option = 217,
 	echo_val_mismatch = 218,
 	oscore_ssn_overflow = 219,
+	oscore_max_interactions = 220,
+	oscore_interaction_duplicated_token = 221,
+	oscore_interaction_not_found = 222,
+	oscore_wrong_uri_path = 223,
 };
 
 /*This macro checks if a function returns an error and if so it propagates 

--- a/inc/oscore/option.h
+++ b/inc/oscore/option.h
@@ -19,7 +19,7 @@
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
 
-#define	OPT_SERIAL_OVERHEAD 5
+#define OPT_SERIAL_OVERHEAD 5
 
 enum o_num {
 	IF_MATCH = 1,
@@ -120,7 +120,8 @@ bool is_observe(struct o_coap_option *options, uint8_t options_cnt);
  *               Set to NULL if not found.
  * @return true if found, false if not.
  */
-bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt, struct byte_array * output);
+bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt,
+		       struct byte_array *output);
 
 /**
  * @brief	Saves an ECHO option value to be compared later with an ECHO value 
@@ -169,6 +170,7 @@ enum err oscore_decrypted_payload_parser(struct byte_array *in_payload,
  * @param uri_path_size Maximum size of the allocated URI Path buffer (input), actual URI Path length (output).
  * @return ok or error code
  */
-enum err uri_path_create(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size);
+enum err uri_path_create(struct o_coap_option *options, uint32_t options_size,
+			 uint8_t *uri_path, uint32_t *uri_path_size);
 
 #endif

--- a/inc/oscore/option.h
+++ b/inc/oscore/option.h
@@ -113,6 +113,16 @@ enum err encode_options(struct o_coap_option *options, uint16_t opt_num,
 bool is_observe(struct o_coap_option *options, uint8_t options_cnt);
 
 /**
+ * @brief Returns the value of OBSERVE option.
+ * @param options Options array.
+ * @param options_cnt Number of entries in the array.
+ * @param output Pointer to byte array which will point to the value buffer.
+ *               Set to NULL if not found.
+ * @return true if found, false if not.
+ */
+bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt, struct byte_array * output);
+
+/**
  * @brief	Saves an ECHO option value to be compared later with an ECHO value 
  * 			received from the client.
  * @param	dest location to save the ECHO value
@@ -149,5 +159,16 @@ enum err oscore_decrypted_payload_parser(struct byte_array *in_payload,
 					 struct o_coap_option *out_E_options,
 					 uint8_t *E_options_cnt,
 					 struct byte_array *out_o_coap_payload);
+
+/**
+ * @brief Compose URI Path (resource name) from given options array.
+ * Implemented based on RFC7252 section 6.5 (partial compliance limited to the library's needs only).
+ * @param options Options array.
+ * @param options_size Options array size (number of items).
+ * @param uri_path Output pointer to write composed URI Path into.
+ * @param uri_path_size Maximum size of the allocated URI Path buffer (input), actual URI Path length (output).
+ * @return ok or error code
+ */
+enum err uri_path_create(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size);
 
 #endif

--- a/inc/oscore/oscore_coap.h
+++ b/inc/oscore/oscore_coap.h
@@ -77,7 +77,7 @@ enum err coap_deserialize(struct byte_array *in, struct o_coap_packet *out);
  * @return  err
  */
 enum err coap_serialize(struct o_coap_packet *in, uint8_t *out_byte_string,
-		  uint32_t *out_byte_string_len);
+			uint32_t *out_byte_string_len);
 
 /**
  * @brief   Convert input options into byte string
@@ -122,6 +122,7 @@ uint8_t opt_extra_bytes(uint16_t delta_or_len);
  * @param msg_type message type
  * @return ok or error code
  */
-enum err coap_get_message_type(struct o_coap_packet * coap_packet,  enum o_coap_msg * msg_type);
+enum err coap_get_message_type(struct o_coap_packet *coap_packet,
+			       enum o_coap_msg *msg_type);
 
 #endif

--- a/inc/oscore/oscore_coap.h
+++ b/inc/oscore/oscore_coap.h
@@ -14,59 +14,9 @@
 
 #include <stdint.h>
 
+#include "oscore_coap_defines.h"
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
-
-#define MAX_TOKEN_LEN 8
-#define MAX_PIV_LEN 5
-#define MAX_KID_CONTEXT_LEN                                                    \
-	8 /*This implementation supports Context IDs up to 8 byte*/
-#define MAX_KID_LEN 8
-#define MAX_AAD_LEN 30
-#define MAX_INFO_LEN 50
-#define MAX_PIV_FIELD_VALUE 0xFFFFFFFFFF /* maximum possible value of SSN/PIV field is 2^40-1, according to RFC 8613 p. 7.2.1.*/
-
-/* Mask and offset for first byte in CoAP/OSCORE header*/
-#define HEADER_LEN 4
-#define HEADER_VERSION_MASK 0xC0
-#define HEADER_VERSION_OFFSET 6
-#define HEADER_TYPE_MASK 0x30
-#define HEADER_TYPE_OFFSET 4
-#define HEADER_TKL_MASK 0x0F
-#define HEADER_TKL_OFFSET 0
-
-/* Mask and offset for first byte in compressed OSCORE option*/
-#define COMP_OSCORE_OPT_KIDC_H_MASK 0x10
-#define COMP_OSCORE_OPT_KIDC_H_OFFSET 4
-#define COMP_OSCORE_OPT_KID_K_MASK 0x08
-#define COMP_OSCORE_OPT_KID_K_OFFSET 3
-#define COMP_OSCORE_OPT_PIV_N_MASK 0x07
-#define COMP_OSCORE_OPT_PIV_N_OFFSET 0
-
-#define ECHO_OPT_VALUE_LEN 12 /*see RFC9175 Appendix A.2*/
-#define OSCORE_OPT_VALUE_LEN                                                   \
-	(2 + MAX_PIV_LEN + MAX_KID_CONTEXT_LEN + MAX_KID_LEN)
-
-#define TYPE_CON 0x00
-#define TYPE_NON 0x01
-#define TYPE_ACK 0x02
-#define TYPE_RST 0x03
-
-#define CODE_CLASS_MASK 0xe0
-#define CODE_DETAIL_MASK 0x1f
-#define CODE_EMPTY 0x00
-#define CODE_REQ_GET 0x01
-#define CODE_REQ_POST 0x02
-#define CODE_REQ_FETCH 0x05
-#define CODE_RESP_CHANGED 0x44
-#define CODE_RESP_CONTENT 0x45
-#define CODE_RESP_UNAUTHORIZED 0x81
-#define REQUEST_CLASS 0x00
-
-#define OPTION_PAYLOAD_MARKER 0xFF
-
-#define MAX_OPTION_COUNT 20
-#define MAX_E_OPTION_COUNT 10
 
 /* all CoAP instances are preceeded with 'o_' to show correspondence to
  * OSCORE and prevent conflicts with networking CoAP libraries 
@@ -165,4 +115,13 @@ bool is_request(struct o_coap_packet *packet);
  * @retval	The needed extra bytes  
 */
 uint8_t opt_extra_bytes(uint16_t delta_or_len);
+
+/**
+ * @brief Get the message type of given coap packet.
+ * @param coap_packet coap packet
+ * @param msg_type message type
+ * @return ok or error code
+ */
+enum err coap_get_message_type(struct o_coap_packet * coap_packet,  enum o_coap_msg * msg_type);
+
 #endif

--- a/inc/oscore/oscore_coap_defines.h
+++ b/inc/oscore/oscore_coap_defines.h
@@ -1,0 +1,84 @@
+/*
+   Copyright (c) 2023 Assa Abloy. See the COPYRIGHT
+   file at the top-level directory of this distribution.
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+*/
+
+#ifndef OSCORE_COAP_DEFINES_H
+#define OSCORE_COAP_DEFINES_H
+
+#define MAX_TOKEN_LEN 8
+#define MAX_PIV_LEN 5
+#define MAX_KID_CONTEXT_LEN                                                    \
+	8 /*This implementation supports Context IDs up to 8 byte*/
+#define MAX_KID_LEN 8
+#define MAX_AAD_LEN 30
+#define MAX_INFO_LEN 50
+#define MAX_PIV_FIELD_VALUE 0xFFFFFFFFFF /* maximum possible value of SSN/PIV field is 2^40-1, according to RFC 8613 p. 7.2.1.*/
+
+/**
+ * @brief Maximum URI Path (resource name) size in bytes.
+ */
+#ifndef OSCORE_MAX_URI_PATH_LEN
+#define OSCORE_MAX_URI_PATH_LEN 30
+#endif
+
+/* Mask and offset for first byte in CoAP/OSCORE header*/
+#define HEADER_LEN 4
+#define HEADER_VERSION_MASK 0xC0
+#define HEADER_VERSION_OFFSET 6
+#define HEADER_TYPE_MASK 0x30
+#define HEADER_TYPE_OFFSET 4
+#define HEADER_TKL_MASK 0x0F
+#define HEADER_TKL_OFFSET 0
+
+/* Mask and offset for first byte in compressed OSCORE option*/
+#define COMP_OSCORE_OPT_KIDC_H_MASK 0x10
+#define COMP_OSCORE_OPT_KIDC_H_OFFSET 4
+#define COMP_OSCORE_OPT_KID_K_MASK 0x08
+#define COMP_OSCORE_OPT_KID_K_OFFSET 3
+#define COMP_OSCORE_OPT_PIV_N_MASK 0x07
+#define COMP_OSCORE_OPT_PIV_N_OFFSET 0
+
+#define ECHO_OPT_VALUE_LEN 12 /*see RFC9175 Appendix A.2*/
+#define OSCORE_OPT_VALUE_LEN                                                   \
+	(2 + MAX_PIV_LEN + MAX_KID_CONTEXT_LEN + MAX_KID_LEN)
+
+#define TYPE_CON 0x00
+#define TYPE_NON 0x01
+#define TYPE_ACK 0x02
+#define TYPE_RST 0x03
+
+#define CODE_CLASS_MASK 0xe0
+#define CODE_DETAIL_MASK 0x1f
+#define CODE_EMPTY 0x00
+#define CODE_REQ_GET 0x01
+#define CODE_REQ_POST 0x02
+#define CODE_REQ_FETCH 0x05
+#define CODE_RESP_CHANGED 0x44
+#define CODE_RESP_CONTENT 0x45
+#define CODE_RESP_UNAUTHORIZED 0x81
+#define REQUEST_CLASS 0x00
+
+#define OPTION_PAYLOAD_MARKER 0xFF
+
+#define MAX_OPTION_COUNT 20
+#define MAX_E_OPTION_COUNT 10
+
+/**
+ * @brief Possible coap message types.
+ */
+enum o_coap_msg {
+   COAP_MSG_REQUEST = 0, /* Regular request */
+   COAP_MSG_REGISTRATION, /* Request with OBSERVE option set to 0 */
+   COAP_MSG_CANCELLATION, /* Request with OBSERVE option set to 1 */
+   COAP_MSG_RESPONSE, /* Regular response */
+   COAP_MSG_NOTIFICATION, /* Response with OBSERVE option */
+};
+
+#endif

--- a/inc/oscore/oscore_coap_defines.h
+++ b/inc/oscore/oscore_coap_defines.h
@@ -19,7 +19,8 @@
 #define MAX_KID_LEN 8
 #define MAX_AAD_LEN 30
 #define MAX_INFO_LEN 50
-#define MAX_PIV_FIELD_VALUE 0xFFFFFFFFFF /* maximum possible value of SSN/PIV field is 2^40-1, according to RFC 8613 p. 7.2.1.*/
+#define MAX_PIV_FIELD_VALUE                                                    \
+	0xFFFFFFFFFF /* maximum possible value of SSN/PIV field is 2^40-1, according to RFC 8613 p. 7.2.1.*/
 
 /**
  * @brief Maximum URI Path (resource name) size in bytes.
@@ -74,11 +75,11 @@
  * @brief Possible coap message types.
  */
 enum o_coap_msg {
-   COAP_MSG_REQUEST = 0, /* Regular request */
-   COAP_MSG_REGISTRATION, /* Request with OBSERVE option set to 0 */
-   COAP_MSG_CANCELLATION, /* Request with OBSERVE option set to 1 */
-   COAP_MSG_RESPONSE, /* Regular response */
-   COAP_MSG_NOTIFICATION, /* Response with OBSERVE option */
+	COAP_MSG_REQUEST = 0, /* Regular request */
+	COAP_MSG_REGISTRATION, /* Request with OBSERVE option set to 0 */
+	COAP_MSG_CANCELLATION, /* Request with OBSERVE option set to 1 */
+	COAP_MSG_RESPONSE, /* Regular response */
+	COAP_MSG_NOTIFICATION, /* Response with OBSERVE option */
 };
 
 #endif

--- a/inc/oscore/oscore_interactions.h
+++ b/inc/oscore/oscore_interactions.h
@@ -1,0 +1,107 @@
+/*
+   Copyright (c) 2023 Assa Abloy. See the COPYRIGHT
+   file at the top-level directory of this distribution.
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+*/
+
+#ifndef OSCORE_INTERACTIONS_H
+#define OSCORE_INTERACTIONS_H
+
+#include <stdint.h>
+#include "oscore/oscore_coap_defines.h"
+#include "common/byte_array.h"
+#include "common/oscore_edhoc_error.h"
+
+/**
+ * @brief Number of interactions supported at the same time, per one OSCORE context.
+ */
+#ifndef OSCORE_INTERACTIONS_COUNT
+#define OSCORE_INTERACTIONS_COUNT 3
+#endif
+
+/**
+ * @brief Single record of interaction between the server and the client.
+ */
+struct oscore_interaction_t
+{
+	enum o_coap_msg request_type; /* Request type, used to distinguish between normal request and resource observations. */
+	uint8_t token[MAX_TOKEN_LEN]; /* CoAP token of the subscription request. */
+	uint8_t token_len;
+	uint8_t uri_paths[OSCORE_MAX_URI_PATH_LEN]; /* Full URI path (all options concatenated to single string). */
+	uint8_t uri_paths_len;
+	uint8_t request_piv[MAX_PIV_LEN]; /* PIV of the subscription request. */
+	uint8_t request_piv_len;
+	uint8_t request_kid[MAX_KID_LEN]; /* KID of the subscription request. */
+	uint8_t request_kid_len;
+	bool is_occupied; /* True if given record is occupied (used in interactions array). */
+};
+
+/**
+ * @brief Initialize interactions array.
+ * 
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_init(struct oscore_interaction_t * interactions);
+
+/**
+ * @brief Add new record to the interactions array, or replace the old one if it exists (URI paths field is used for comparison).
+ * @note To be used while registering to given resource.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param record Single record to be added or updated.
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_set_record(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record);
+
+/**
+ * @brief Search for the record matching given token and return a pointer to it.
+ * @note To be used while encrypting a notification on the server side, and confirming its AAD on the client side.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param token Token buffer to match.
+ * @param token_len Token buffer size.
+ * @param record [out] Pointer to the matching record.
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_get_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, struct oscore_interaction_t ** record);
+
+/**
+ * @brief Remove a record that matches given URI paths field.
+ * @note To be used while de-registering to given resource.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param token Token buffer to match.
+ * @param token_len Token buffer size.
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_remove_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len);
+
+/**
+ * @brief Wrapper for handling OSCORE interactions to be executed before main encryption/decryption logic.
+ * 
+ * @param msg_type Message type of the packet.
+ * @param token Token byte array. MUST NOT be NULL, but can be empty.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param request_piv Output request_piv (to be updated if needed).
+ * @param request_kid Output request_kid (to be updated if needed).
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid);
+
+/**
+ * @brief Wrapper for handling OSCORE interactions to be executed after main encryption/decryption logic.
+ * 
+ * @param msg_type Message type of the packet.
+ * @param token Token byte array. MUST NOT be NULL, but can be empty.
+ * @param uri_paths URI Paths byte array. MUST NOT be null, but can be empty.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param request_piv Current value of request_piv.
+ * @param request_kid Current value of request_kid.
+ * @return enum err ok, or error if failed.
+ */
+enum err oscore_interactions_update_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct byte_array *uri_paths, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid);
+
+#endif

--- a/inc/oscore/oscore_interactions.h
+++ b/inc/oscore/oscore_interactions.h
@@ -27,18 +27,28 @@
 /**
  * @brief Single record of interaction between the server and the client.
  */
-struct oscore_interaction_t
-{
-	enum o_coap_msg request_type; /* Request type, used to distinguish between normal request and resource observations. */
-	uint8_t token[MAX_TOKEN_LEN]; /* CoAP token of the subscription request. */
+struct oscore_interaction_t {
+	/* Request type, used to distinguish between normal request and resource observations. */
+	enum o_coap_msg request_type;
+
+	/* CoAP token of the subscription request. */
+	uint8_t token[MAX_TOKEN_LEN];
 	uint8_t token_len;
-	uint8_t uri_paths[OSCORE_MAX_URI_PATH_LEN]; /* Full URI path (all options concatenated to single string). */
+
+	/* Full URI path (all options concatenated to single string). */
+	uint8_t uri_paths[OSCORE_MAX_URI_PATH_LEN];
 	uint8_t uri_paths_len;
-	uint8_t request_piv[MAX_PIV_LEN]; /* PIV of the subscription request. */
+
+	/* PIV of the subscription request. */
+	uint8_t request_piv[MAX_PIV_LEN];
 	uint8_t request_piv_len;
-	uint8_t request_kid[MAX_KID_LEN]; /* KID of the subscription request. */
+
+	/* KID of the subscription request. */
+	uint8_t request_kid[MAX_KID_LEN];
 	uint8_t request_kid_len;
-	bool is_occupied; /* True if given record is occupied (used in interactions array). */
+
+	/* True if given record is occupied (used in interactions array). */
+	bool is_occupied;
 };
 
 /**
@@ -47,7 +57,7 @@ struct oscore_interaction_t
  * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_init(struct oscore_interaction_t * interactions);
+enum err oscore_interactions_init(struct oscore_interaction_t *interactions);
 
 /**
  * @brief Add new record to the interactions array, or replace the old one if it exists (URI paths field is used for comparison).
@@ -56,7 +66,9 @@ enum err oscore_interactions_init(struct oscore_interaction_t * interactions);
  * @param record Single record to be added or updated.
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_set_record(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record);
+enum err
+oscore_interactions_set_record(struct oscore_interaction_t *interactions,
+			       struct oscore_interaction_t *record);
 
 /**
  * @brief Search for the record matching given token and return a pointer to it.
@@ -67,7 +79,10 @@ enum err oscore_interactions_set_record(struct oscore_interaction_t * interactio
  * @param record [out] Pointer to the matching record.
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_get_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, struct oscore_interaction_t ** record);
+enum err
+oscore_interactions_get_record(struct oscore_interaction_t *interactions,
+			       uint8_t *token, uint8_t token_len,
+			       struct oscore_interaction_t **record);
 
 /**
  * @brief Remove a record that matches given URI paths field.
@@ -77,7 +92,9 @@ enum err oscore_interactions_get_record(struct oscore_interaction_t * interactio
  * @param token_len Token buffer size.
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_remove_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len);
+enum err
+oscore_interactions_remove_record(struct oscore_interaction_t *interactions,
+				  uint8_t *token, uint8_t token_len);
 
 /**
  * @brief Wrapper for handling OSCORE interactions to be executed before main encryption/decryption logic.
@@ -89,7 +106,10 @@ enum err oscore_interactions_remove_record(struct oscore_interaction_t * interac
  * @param request_kid Output request_kid (to be updated if needed).
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid);
+enum err oscore_interactions_read_wrapper(
+	enum o_coap_msg msg_type, struct byte_array *token,
+	struct oscore_interaction_t *interactions,
+	struct byte_array *request_piv, struct byte_array *request_kid);
 
 /**
  * @brief Wrapper for handling OSCORE interactions to be executed after main encryption/decryption logic.
@@ -102,6 +122,9 @@ enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_
  * @param request_kid Current value of request_kid.
  * @return enum err ok, or error if failed.
  */
-enum err oscore_interactions_update_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct byte_array *uri_paths, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid);
+enum err oscore_interactions_update_wrapper(
+	enum o_coap_msg msg_type, struct byte_array *token,
+	struct byte_array *uri_paths, struct oscore_interaction_t *interactions,
+	struct byte_array *request_piv, struct byte_array *request_kid);
 
 #endif

--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -122,5 +122,4 @@ enum err piv2ssn(struct byte_array *piv, uint64_t *ssn);
  */
 enum err check_context_freshness(struct context *c);
 
-
 #endif

--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -15,6 +15,7 @@
 #include "supported_algorithm.h"
 #include "oscore_coap.h"
 #include "oscore/replay_protection.h"
+#include "oscore/oscore_interactions.h"
 
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
@@ -81,11 +82,7 @@ struct req_resp_context {
 	struct byte_array nonce;
 	uint8_t nonce_buf[NONCE_LEN];
 
-	struct byte_array request_kid;
-	uint8_t request_kid_buf[MAX_KID_LEN];
-
-	struct byte_array request_piv;
-	uint8_t request_piv_buf[MAX_PIV_LEN];
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
 
 	struct byte_array echo_opt_val;
 	uint8_t echo_opt_val_buf[ECHO_OPT_VALUE_LEN];
@@ -116,17 +113,6 @@ enum err ssn2piv(uint64_t ssn, struct byte_array *piv);
  * @param ssn Sender Sequence Number
  */
 enum err piv2ssn(struct byte_array *piv, uint64_t *ssn);
-
-/**
- * @brief	Updates the request_piv and the request_kid
- * @param	c the context
- * @param	piv	the new PIV
- * @param 	kid the new KID
- * @retval 	error code
-*/
-enum err update_request_piv_request_kid(struct context *c,
-					struct byte_array *piv,
-					struct byte_array *kid);
 
 /**
  * @brief Check if given security context is still safe to be used, or a new one must be established.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "_comment": "see https://travishorn.com/semantic-versioning-with-git-tags-1ef2d4aeede6   npm version patch, npm version minor, npm version major, git push --follow-tags",
     "name": "uoscore-uedhoc",
-    "version": "2.1.5"
+    "version": "2.2.0"
 }

--- a/src/common/print_util.c
+++ b/src/common/print_util.c
@@ -32,11 +32,14 @@ static const char external_runtime_error_message[] = {
 void print_array(const uint8_t *in_data, uint32_t in_len)
 {
 	printf(" (size %lu):", (unsigned long)in_len);
-	for (uint32_t i = 0; i < in_len; i++) {
-		if (i % 16 == 0)
-			printf("\n\t%02X ", in_data[i]);
-		else
-			printf("%02X ", in_data[i]);
+	if (NULL != in_data)
+	{
+		for (uint32_t i = 0; i < in_len; i++) {
+			if (i % 16 == 0)
+				printf("\n\t%02X ", in_data[i]);
+			else
+				printf("%02X ", in_data[i]);
+		}
 	}
 	printf("\n");
 }

--- a/src/common/print_util.c
+++ b/src/common/print_util.c
@@ -32,8 +32,7 @@ static const char external_runtime_error_message[] = {
 void print_array(const uint8_t *in_data, uint32_t in_len)
 {
 	printf(" (size %lu):", (unsigned long)in_len);
-	if (NULL != in_data)
-	{
+	if (NULL != in_data) {
 		for (uint32_t i = 0; i < in_len; i++) {
 			if (i % 16 == 0)
 				printf("\n\t%02X ", in_data[i]);

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -83,9 +83,8 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 			* Inner option has value NULL if notification or the original value 
 			* in the coap packet if registration/cancellation.
 			*/
-			e_options[*e_options_cnt].delta =
-				(uint16_t)(temp_option_nr -
-					   temp_E_option_delta_sum);
+			e_options[*e_options_cnt].delta = (uint16_t)(
+				temp_option_nr - temp_E_option_delta_sum);
 			if (is_request(in_o_coap)) {
 				/*registrations/cancellations are requests */
 				e_options[*e_options_cnt].len = temp_len;
@@ -119,9 +118,8 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 			/*
 			*outer option (value as in the original coap packet
 			*/
-			U_options[*U_options_cnt].delta =
-				(uint16_t)(temp_option_nr -
-					   temp_U_option_delta_sum);
+			U_options[*U_options_cnt].delta = (uint16_t)(
+				temp_option_nr - temp_U_option_delta_sum);
 			U_options[*U_options_cnt].len = temp_len;
 			U_options[*U_options_cnt].value =
 				in_o_coap->options[i].value;
@@ -152,10 +150,9 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 					temp_option_nr;
 
 				/* Update delta sum of E-options */
-				temp_E_option_delta_sum =
-					(uint8_t)(temp_E_option_delta_sum +
-						  e_options[*e_options_cnt]
-							  .delta);
+				temp_E_option_delta_sum = (uint8_t)(
+					temp_E_option_delta_sum +
+					e_options[*e_options_cnt].delta);
 
 				/* Increment E-options count */
 				(*e_options_cnt)++;
@@ -175,10 +172,9 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 					temp_option_nr;
 
 				/* Update delta sum of E-options */
-				temp_U_option_delta_sum =
-					(uint8_t)(temp_U_option_delta_sum +
-						  U_options[*U_options_cnt]
-							  .delta);
+				temp_U_option_delta_sum = (uint8_t)(
+					temp_U_option_delta_sum +
+					U_options[*U_options_cnt].delta);
 
 				/* Increment E-options count */
 				(*U_options_cnt)++;
@@ -305,9 +301,9 @@ STATIC enum err oscore_option_generate(struct byte_array *piv,
 				(uint8_t)(oscore_option->value[0] | piv->len);
 			/* copy PIV (sender sequence) */
 
-			dest_size = (uint32_t)(oscore_option->len -
-					       (temp_ptr + 1 -
-						oscore_option->value));
+			dest_size = (uint32_t)(
+				oscore_option->len -
+				(temp_ptr + 1 - oscore_option->value));
 			TRY(_memcpy_s(++temp_ptr, dest_size, piv->ptr,
 				      piv->len));
 
@@ -322,9 +318,9 @@ STATIC enum err oscore_option_generate(struct byte_array *piv,
 			/* Copy length and context value */
 			*temp_ptr = (uint8_t)(kid_context->len);
 
-			dest_size = (uint32_t)(oscore_option->len -
-					       (temp_ptr + 1 -
-						oscore_option->value));
+			dest_size = (uint32_t)(
+				oscore_option->len -
+				(temp_ptr + 1 - oscore_option->value));
 			TRY(_memcpy_s(++temp_ptr, dest_size, kid_context->ptr,
 				      kid_context->len));
 
@@ -457,17 +453,16 @@ static enum err generate_new_ssn(struct context *c)
 
 	c->sc.ssn++;
 
-	#ifdef OSCORE_NVM_SUPPORT
-		struct nvm_key_t nvm_key = { .sender_id = c->sc.sender_id,
-						.recipient_id = c->rc.recipient_id,
-						.id_context = c->cc.id_context };
-		bool echo_sync_in_progress =
-			(ECHO_SYNCHRONIZED != c->rrc.echo_state_machine);
-		return ssn_store_in_nvm(&nvm_key, c->sc.ssn,
-					echo_sync_in_progress);
-	#else
-		return ok;
-	#endif
+#ifdef OSCORE_NVM_SUPPORT
+	struct nvm_key_t nvm_key = { .sender_id = c->sc.sender_id,
+				     .recipient_id = c->rc.recipient_id,
+				     .id_context = c->cc.id_context };
+	bool echo_sync_in_progress =
+		(ECHO_SYNCHRONIZED != c->rrc.echo_state_machine);
+	return ssn_store_in_nvm(&nvm_key, c->sc.ssn, echo_sync_in_progress);
+#else
+	return ok;
+#endif
 }
 
 /**
@@ -516,7 +511,8 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 	/* Read necessary fields from the input packet. */
 	enum o_coap_msg msg_type;
 	TRY(coap_get_message_type(input_coap, &msg_type));
-	struct byte_array token = BYTE_ARRAY_INIT(input_coap->token, input_coap->header.TKL);
+	struct byte_array token =
+		BYTE_ARRAY_INIT(input_coap->token, input_coap->header.TKL);
 
 	/* Generate new PIV/nonce if needed. */
 	bool use_new_piv = needs_new_piv(msg_type, c->rrc.echo_state_machine);
@@ -543,8 +539,11 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 	BYTE_ARRAY_NEW(aad, MAX_AAD_LEN, MAX_AAD_LEN);
 	struct byte_array request_piv = piv;
 	struct byte_array request_kid = kid;
-	TRY(oscore_interactions_read_wrapper(msg_type, &token, c->rrc.interactions, &request_piv, &request_kid));
-	TRY(create_aad(NULL, 0, c->cc.aead_alg, &request_kid, &request_piv, &aad));
+	TRY(oscore_interactions_read_wrapper(msg_type, &token,
+					     c->rrc.interactions, &request_piv,
+					     &request_kid));
+	TRY(create_aad(NULL, 0, c->cc.aead_alg, &request_kid, &request_piv,
+		       &aad));
 
 	/* Encrypt the plaintext */
 	TRY(oscore_cose_encrypt(plaintext, ciphertext, &nonce, &aad,
@@ -556,10 +555,14 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 	}
 
 	/* Handle OSCORE interactions after successful encryption. */
-	BYTE_ARRAY_NEW(uri_paths, OSCORE_MAX_URI_PATH_LEN, OSCORE_MAX_URI_PATH_LEN);
-	TRY(uri_path_create(input_coap->options, input_coap->options_cnt, uri_paths.ptr, &(uri_paths.len)));
-	TRY(oscore_interactions_update_wrapper(msg_type, &token, &uri_paths, c->rrc.interactions, &request_piv, &request_kid));
-	
+	BYTE_ARRAY_NEW(uri_paths, OSCORE_MAX_URI_PATH_LEN,
+		       OSCORE_MAX_URI_PATH_LEN);
+	TRY(uri_path_create(input_coap->options, input_coap->options_cnt,
+			    uri_paths.ptr, &(uri_paths.len)));
+	TRY(oscore_interactions_update_wrapper(msg_type, &token, &uri_paths,
+					       c->rrc.interactions,
+					       &request_piv, &request_kid));
+
 	return ok;
 }
 
@@ -637,15 +640,16 @@ enum err coap2oscore(uint8_t *buf_o_coap, uint32_t buf_o_coap_len,
 	BYTE_ARRAY_NEW(ciphertext, MAX_CIPHERTEXT_LEN,
 		       plaintext.len + AUTH_TAG_LEN);
 
-	if (ECHO_VERIFY == c->rrc.echo_state_machine)
-	{
+	if (ECHO_VERIFY == c->rrc.echo_state_machine) {
 		/* A server prepares a response with ECHO challenge after the reboot. */
-		TRY(cache_echo_val(&c->rrc.echo_opt_val, e_options, e_options_cnt));
+		TRY(cache_echo_val(&c->rrc.echo_opt_val, e_options,
+				   e_options_cnt));
 	}
 
 	/* Encrypt data using either a freshly generated nonce (if needed), or the one cached from the corresponding request. */
 	struct oscore_option oscore_option;
-	TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &o_coap_pkt, &oscore_option));
+	TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &o_coap_pkt,
+			    &oscore_option));
 
 	/*create an OSCORE packet*/
 	struct o_coap_packet oscore_pkt;

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -471,6 +471,24 @@ static enum err generate_new_ssn(struct context *c)
 }
 
 /**
+ * @brief Checks if given message needs a fresh PIV/nonce, based on its type and current state of ECHO challenge.
+ * @param msg_type Message type.
+ * @param echo_state ECHO challenge state.
+ * @return If true, new PIV/nonce must be generated.
+ */
+static bool needs_new_piv(enum o_coap_msg msg_type, enum echo_state echo_state)
+{
+	/* Encrypt data using new PIV/nonce in the following cases:
+		- Client prepares any kind of request.
+		- Server prepares a response with ECHO challenge after the reboot (see RFC 8613 Appendix B.1.2).
+		- Server prepares a notification (response) to an observe registration.
+	   Encrypt data using corresponding request nonce:
+		- Server prepares a response to a request after the ECHO challenge.
+	   For more details, see RFC 8613 p. 8.3 and the following hyperlinks.*/
+	return ((COAP_MSG_RESPONSE != msg_type) || (ECHO_VERIFY == echo_state));
+}
+
+/**
  * @brief Wrapper function with common operations for encrypting the payload.
  *        These operations are shared in all possible scenarios.
  *        For more info, see RFC8616 8.1 and 8.3.
@@ -478,77 +496,70 @@ static enum err generate_new_ssn(struct context *c)
  * @param plaintext Input plaintext to be encrypted.
  * @param ciphertext Output encrypted payload for the OSCORE packet.
  * @param c Security context.
+ * @param input_coap Input coap packet.
  * @param oscore_option Output OSCORE option.
- * @param is_request True if the packet is request and needs special handling while generating AAD.
- * @param use_new_piv True for cases when new PIV/nonce should be generated.
  * @return enum err 
  */
 static enum err encrypt_wrapper(struct byte_array *plaintext,
 				struct byte_array *ciphertext,
 				struct context *c,
-				struct oscore_option *oscore_option,
-				bool is_request, bool use_new_piv)
+				struct o_coap_packet *input_coap,
+				struct oscore_option *oscore_option)
 {
 	BYTE_ARRAY_NEW(new_piv, MAX_PIV_LEN, MAX_PIV_LEN);
 	BYTE_ARRAY_NEW(new_nonce, NONCE_LEN, NONCE_LEN);
-	struct byte_array *piv = NULL;
-	struct byte_array *kid = NULL;
-	struct byte_array *kid_context = NULL;
-	struct byte_array *nonce;
+	struct byte_array piv = BYTE_ARRAY_INIT(NULL, 0);
+	struct byte_array kid = BYTE_ARRAY_INIT(NULL, 0);
+	struct byte_array kid_context = BYTE_ARRAY_INIT(NULL, 0);
+	struct byte_array nonce;
 
+	/* Read necessary fields from the input packet. */
+	enum o_coap_msg msg_type;
+	TRY(coap_get_message_type(input_coap, &msg_type));
+	struct byte_array token = BYTE_ARRAY_INIT(input_coap->token, input_coap->header.TKL);
+
+	/* Generate new PIV/nonce if needed. */
+	bool use_new_piv = needs_new_piv(msg_type, c->rrc.echo_state_machine);
 	if (use_new_piv) {
-		/* Generate new PIV and nonce if needed. */
 		TRY(ssn2piv(c->sc.ssn, &new_piv));
 		TRY(generate_new_ssn(c));
 		TRY(create_nonce(&c->sc.sender_id, &new_piv, &c->cc.common_iv,
 				 &new_nonce));
 
-		nonce = &new_nonce;
-		piv = &new_piv;
-		kid = &c->sc.sender_id;
-		kid_context = &c->cc.id_context;
+		nonce = new_nonce;
+		piv = new_piv;
+		kid = c->sc.sender_id;
+		kid_context = c->cc.id_context;
 	} else {
-		/* Regular response:
-		- PIV is not present
-		- KID usage don't apply as the library doesn't support group communication
-		- KID context usage don't apply, as the library use Appendix B.1 instead of B.2.
-		- rrc.nonce from the request is used
-		For more details, see 8.3 and the following hyperlinks. */
-		nonce = &c->rrc.nonce;
+		nonce = c->rrc.nonce;
 	}
 
 	/* Generate OSCORE option based on selected values. */
-	TRY(oscore_option_generate(piv, kid, kid_context, oscore_option));
-
-	/* Set proper arrays for AAD
-	   for responses, use stored values of the corresponding request;
-	   for requests, use current values of PIV and Sender ID. */
-	struct byte_array *request_piv = &c->rrc.request_piv;
-	struct byte_array *request_kid = &c->rrc.request_kid;
-	if (is_request) {
-		request_piv = piv;
-		request_kid = kid;
-	}
+	TRY(oscore_option_generate(&piv, &kid, &kid_context, oscore_option));
 
 	/* AAD shares the same format for both requests and responses, 
 	   yet request_kid and request_piv fields are only used by responses.
 	   For more details, see 5.4. */
 	BYTE_ARRAY_NEW(aad, MAX_AAD_LEN, MAX_AAD_LEN);
-	TRY(create_aad(NULL, 0, c->cc.aead_alg, request_kid, request_piv,
-		       &aad));
+	struct byte_array request_piv = piv;
+	struct byte_array request_kid = kid;
+	TRY(oscore_interactions_read_wrapper(msg_type, &token, c->rrc.interactions, &request_piv, &request_kid));
+	TRY(create_aad(NULL, 0, c->cc.aead_alg, &request_kid, &request_piv, &aad));
 
 	/* Encrypt the plaintext */
-	TRY(oscore_cose_encrypt(plaintext, ciphertext, nonce, &aad,
+	TRY(oscore_cose_encrypt(plaintext, ciphertext, &nonce, &aad,
 				&c->sc.sender_key));
 
-	/* Update rrc fields only after successful encryption (for handling future responses). */
-	if (is_request) {
-		TRY(update_request_piv_request_kid(c, piv, kid));
-	}
+	/* Update nonce only after successful encryption (for handling future responses). */
 	if (use_new_piv) {
-		TRY(byte_array_cpy(&c->rrc.nonce, nonce, NONCE_LEN));
+		TRY(byte_array_cpy(&c->rrc.nonce, &nonce, NONCE_LEN));
 	}
 
+	/* Handle OSCORE interactions after successful encryption. */
+	BYTE_ARRAY_NEW(uri_paths, OSCORE_MAX_URI_PATH_LEN, OSCORE_MAX_URI_PATH_LEN);
+	TRY(uri_path_create(input_coap->options, input_coap->options_cnt, uri_paths.ptr, &(uri_paths.len)));
+	TRY(oscore_interactions_update_wrapper(msg_type, &token, &uri_paths, c->rrc.interactions, &request_piv, &request_kid));
+	
 	return ok;
 }
 
@@ -626,42 +637,15 @@ enum err coap2oscore(uint8_t *buf_o_coap, uint32_t buf_o_coap_len,
 	BYTE_ARRAY_NEW(ciphertext, MAX_CIPHERTEXT_LEN,
 		       plaintext.len + AUTH_TAG_LEN);
 
-	struct oscore_option oscore_option;
-	bool request = is_request(&o_coap_pkt);
-	if (request) {
-		/*a client prepares a request*/
-
-		/* Encrypt data using new PIV/nonce */
-		TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &oscore_option,
-				    request, true));
-
-	} else if (ECHO_VERIFY == c->rrc.echo_state_machine) {
-		/* A server prepares a response with ECHO challenge after the reboot.*/
-		TRY(cache_echo_val(&c->rrc.echo_opt_val, e_options,
-				   e_options_cnt));
-
-		/*Note that even if this is a response the server
-		 MUST use its Partial IV when generating the AEAD nonce and MUST
-		 include the Partial IV in the response, see Appendix B.1.2*/
-		TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &oscore_option,
-				    request, true));
-
-	} else if (is_observe(u_options, u_options_cnt)) {
-		/*A server prepares a notification (response) to a observe registration.
-		 However not the first response*/
-
-		/* Encrypt data using new PIV/nonce */
-		TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &oscore_option,
-				    request, true));
-
-	} else {
-		/* A server prepares a response to a regular request. 
-		However not the first response. */
-
-		/* Encrypt data using corresponding request nonce. */
-		TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &oscore_option,
-				    request, false));
+	if (ECHO_VERIFY == c->rrc.echo_state_machine)
+	{
+		/* A server prepares a response with ECHO challenge after the reboot. */
+		TRY(cache_echo_val(&c->rrc.echo_opt_val, e_options, e_options_cnt));
 	}
+
+	/* Encrypt data using either a freshly generated nonce (if needed), or the one cached from the corresponding request. */
+	struct oscore_option oscore_option;
+	TRY(encrypt_wrapper(&plaintext, &ciphertext, c, &o_coap_pkt, &oscore_option));
 
 	/*create an OSCORE packet*/
 	struct o_coap_packet oscore_pkt;

--- a/src/oscore/option.c
+++ b/src/oscore/option.c
@@ -16,7 +16,6 @@
 
 #include "common/memcpy_s.h"
 
-
 /**
  * @brief Securely append a substring to given buffer.
  * 
@@ -27,10 +26,15 @@
  * @param substring_size Substring size.
  * @return ok or error
  */
-static enum err buffer_append(uint8_t *buffer, uint32_t * current_size, uint32_t max_size, const uint8_t * substring, uint32_t substring_size )
+static enum err buffer_append(uint8_t *buffer, uint32_t *current_size,
+			      uint32_t max_size, const uint8_t *substring,
+			      uint32_t substring_size)
 {
-	uint8_t * destination = &buffer[*current_size]; //pointer to current end of the content
-	uint32_t remaining_size = max_size - (*current_size); //how many bytes in the buffer are still available
+	uint8_t *destination =
+		&buffer[*current_size]; //pointer to current end of the content
+	uint32_t remaining_size =
+		max_size -
+		(*current_size); //how many bytes in the buffer are still available
 	TRY(_memcpy_s(destination, remaining_size, substring, substring_size));
 	*current_size += substring_size;
 	return ok;
@@ -53,10 +57,10 @@ bool is_observe(struct o_coap_option *options, uint8_t options_cnt)
 	return false;
 }
 
-bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt, struct byte_array * output)
+bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt,
+		       struct byte_array *output)
 {
-	if ((NULL == options) || (NULL == output))
-	{
+	if ((NULL == options) || (NULL == output)) {
 		return false;
 	}
 
@@ -139,10 +143,11 @@ enum err echo_val_is_fresh(struct byte_array *cache_val,
 	return no_echo_option;
 }
 
-enum err uri_path_create(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size)
+enum err uri_path_create(struct o_coap_option *options, uint32_t options_size,
+			 uint8_t *uri_path, uint32_t *uri_path_size)
 {
-	if ((NULL == options) || (NULL == uri_path) || (NULL == uri_path_size))
-	{
+	if ((NULL == options) || (NULL == uri_path) ||
+	    (NULL == uri_path_size)) {
 		return wrong_parameter;
 	}
 
@@ -153,30 +158,26 @@ enum err uri_path_create(struct o_coap_option *options, uint32_t options_size, u
 	const uint8_t delimiter = '/';
 	const uint32_t delimiter_size = 1;
 
-	for (uint32_t index = 0; index < options_size; index++)
-	{
-		struct o_coap_option * option = &options[index];
-		if (URI_PATH != option->option_number)
-		{
+	for (uint32_t index = 0; index < options_size; index++) {
+		struct o_coap_option *option = &options[index];
+		if (URI_PATH != option->option_number) {
 			continue;
 		}
-		if ((0 != option->len) && (NULL == option->value))
-		{
+		if ((0 != option->len) && (NULL == option->value)) {
 			return oscore_wrong_uri_path;
 		}
 
-		TRY(buffer_append(uri_path, &current_size, max_size, option->value, option->len));
-		TRY(buffer_append(uri_path, &current_size, max_size, &delimiter, delimiter_size));
+		TRY(buffer_append(uri_path, &current_size, max_size,
+				  option->value, option->len));
+		TRY(buffer_append(uri_path, &current_size, max_size, &delimiter,
+				  delimiter_size));
 	}
 
 	/* Remove last '/' character, or add a single one if the path is empty */
-	if (current_size > 0)
-	{
+	if (current_size > 0) {
 		uri_path[current_size] = 0;
 		current_size--;
-	}
-	else
-	{
+	} else {
 		uri_path[0] = delimiter;
 		current_size = delimiter_size;
 	}

--- a/src/oscore/option.c
+++ b/src/oscore/option.c
@@ -16,6 +16,26 @@
 
 #include "common/memcpy_s.h"
 
+
+/**
+ * @brief Securely append a substring to given buffer.
+ * 
+ * @param buffer Buffer to have the substring appended.
+ * @param current_size Current size of the buffer content. Updated after successfull append.
+ * @param max_size Memory size allocated for the buffer.
+ * @param substring Substring buffer to be appended.
+ * @param substring_size Substring size.
+ * @return ok or error
+ */
+static enum err buffer_append(uint8_t *buffer, uint32_t * current_size, uint32_t max_size, const uint8_t * substring, uint32_t substring_size )
+{
+	uint8_t * destination = &buffer[*current_size]; //pointer to current end of the content
+	uint32_t remaining_size = max_size - (*current_size); //how many bytes in the buffer are still available
+	TRY(_memcpy_s(destination, remaining_size, substring, substring_size));
+	*current_size += substring_size;
+	return ok;
+}
+
 bool is_class_e(uint16_t code)
 {
 	// blacklist, because OSCORE dictates that unknown options SHALL be processed as class E
@@ -30,6 +50,26 @@ bool is_observe(struct o_coap_option *options, uint8_t options_cnt)
 			return true;
 		}
 	}
+	return false;
+}
+
+bool get_observe_value(struct o_coap_option *options, uint8_t options_cnt, struct byte_array * output)
+{
+	if ((NULL == options) || (NULL == output))
+	{
+		return false;
+	}
+
+	for (uint8_t i = 0; i < options_cnt; i++) {
+		if (OBSERVE != options[i].option_number) {
+			continue;
+		}
+
+		output->ptr = options[i].value;
+		output->len = options[i].len;
+		return true;
+	}
+	output = NULL;
 	return false;
 }
 
@@ -48,15 +88,6 @@ enum err cache_echo_val(struct byte_array *dest, struct o_coap_option *options,
 	return no_echo_option;
 }
 
-/**
- * @brief Parse the decrypted OSCORE payload into code, E-options and original unprotected CoAP payload
- * @param in_payload: input decrypted payload
- * @param out_code: pointer to code number of the request
- * @param out_E_options: output pointer to an array of E-options
- * @param E_options_cnt: count number of E-options
- * @param out_o_coap_payload: output pointer original unprotected CoAP payload
- * @return  err
- */
 enum err oscore_decrypted_payload_parser(struct byte_array *in_payload,
 					 uint8_t *out_code,
 					 struct o_coap_option *out_E_options,
@@ -106,4 +137,50 @@ enum err echo_val_is_fresh(struct byte_array *cache_val,
 	}
 
 	return no_echo_option;
+}
+
+enum err uri_path_create(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size)
+{
+	if ((NULL == options) || (NULL == uri_path) || (NULL == uri_path_size))
+	{
+		return wrong_parameter;
+	}
+
+	uint32_t current_size = 0;
+	uint32_t max_size = *uri_path_size;
+	memset(uri_path, 0, max_size);
+
+	const uint8_t delimiter = '/';
+	const uint32_t delimiter_size = 1;
+
+	for (uint32_t index = 0; index < options_size; index++)
+	{
+		struct o_coap_option * option = &options[index];
+		if (URI_PATH != option->option_number)
+		{
+			continue;
+		}
+		if ((0 != option->len) && (NULL == option->value))
+		{
+			return oscore_wrong_uri_path;
+		}
+
+		TRY(buffer_append(uri_path, &current_size, max_size, option->value, option->len));
+		TRY(buffer_append(uri_path, &current_size, max_size, &delimiter, delimiter_size));
+	}
+
+	/* Remove last '/' character, or add a single one if the path is empty */
+	if (current_size > 0)
+	{
+		uri_path[current_size] = 0;
+		current_size--;
+	}
+	else
+	{
+		uri_path[0] = delimiter;
+		current_size = delimiter_size;
+	}
+
+	*uri_path_size = current_size;
+	return ok;
 }

--- a/src/oscore/oscore_coap.c
+++ b/src/oscore/oscore_coap.c
@@ -346,40 +346,39 @@ bool is_request(struct o_coap_packet *packet)
 	}
 }
 
-enum err coap_get_message_type(struct o_coap_packet * coap_packet,  enum o_coap_msg * msg_type)
+enum err coap_get_message_type(struct o_coap_packet *coap_packet,
+			       enum o_coap_msg *msg_type)
 {
-	if ((NULL == coap_packet) || (NULL == msg_type))
-	{
+	if ((NULL == coap_packet) || (NULL == msg_type)) {
 		return wrong_parameter;
 	}
 
 	enum o_coap_msg result;
 	struct byte_array observe;
-	bool observe_valid = get_observe_value(coap_packet->options, coap_packet->options_cnt, &observe);
+	bool observe_valid = get_observe_value(
+		coap_packet->options, coap_packet->options_cnt, &observe);
 	bool request = is_request(coap_packet);
-	if (request)
-	{
+	if (request) {
 		// packet can be a request, a registration or a cancellation
 		result = COAP_MSG_REQUEST;
-		if (observe_valid)
-		{
-			if ((0 == observe.len) || 
-			   ((1 == observe.len) && (OSCORE_OBSERVE_REGISTRATION_VALUE == observe.ptr[0])))
-			{
+		if (observe_valid) {
+			if ((0 == observe.len) ||
+			    ((1 == observe.len) &&
+			     (OSCORE_OBSERVE_REGISTRATION_VALUE ==
+			      observe.ptr[0]))) {
 				/* Empty uint option is interpreted as a value 0.
 				   For more info, see RFC 7252 section 3.2. */
 				result = COAP_MSG_REGISTRATION;
-			}
-			else if ((1 == observe.len) && (OSCORE_OBSERVE_CANCELLATION_VALUE == observe.ptr[0]))
-			{
+			} else if ((1 == observe.len) &&
+				   (OSCORE_OBSERVE_CANCELLATION_VALUE ==
+				    observe.ptr[0])) {
 				result = COAP_MSG_CANCELLATION;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		// packet can be a regular response or a notification
-		result = (observe_valid ? COAP_MSG_NOTIFICATION : COAP_MSG_RESPONSE);
+		result = (observe_valid ? COAP_MSG_NOTIFICATION :
+					  COAP_MSG_RESPONSE);
 	}
 
 	*msg_type = result;

--- a/src/oscore/oscore_interactions.c
+++ b/src/oscore/oscore_interactions.c
@@ -18,8 +18,10 @@
 #include "common/print_util.h"
 
 #ifdef DEBUG_PRINT
-static const char msg_interaction_not_found[] = "Couldn't find the interaction with given key.\n";
-static const char msg_token_already_used[] = "Given token is already used by other interaction (index=%u).\n";
+static const char msg_interaction_not_found[] =
+	"Couldn't find the interaction with given key.\n";
+static const char msg_token_already_used[] =
+	"Given token is already used by other interaction (index=%u).\n";
 
 /**
  * @brief Print single interaction field.
@@ -28,13 +30,12 @@ static const char msg_token_already_used[] = "Given token is already used by oth
  * @param buffer Field buffer.
  * @param len Buffer size in bytes.
  */
-static void print_interaction_field(const char * name, uint8_t * buffer, uint32_t len)
+static void print_interaction_field(const char *name, uint8_t *buffer,
+				    uint32_t len)
 {
 	PRINTF("   %s: ", name);
-	if (NULL != buffer)
-	{
-		for (uint32_t index = 0; index < len; index++)
-		{
+	if (NULL != buffer) {
+		for (uint32_t index = 0; index < len; index++) {
 			PRINTF("%02x ", buffer[index]);
 		}
 	}
@@ -46,25 +47,31 @@ static void print_interaction_field(const char * name, uint8_t * buffer, uint32_
  * 
  * @param interactions Input interactions array.
  */
-static void print_interactions(struct oscore_interaction_t * interactions)
+static void print_interactions(struct oscore_interaction_t *interactions)
 {
-	for (uint8_t index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
-	{
+	for (uint8_t index = 0; index < OSCORE_INTERACTIONS_COUNT; index++) {
 		struct oscore_interaction_t *record = &interactions[index];
 		PRINTF("record %02u:\n", index);
 		PRINTF("   type     : %d\n", record->request_type);
-		print_interaction_field("uri paths", record->uri_paths, record->uri_paths_len);
-		print_interaction_field("token    ", record->token, record->token_len);
-		print_interaction_field("req_piv  ", record->request_piv, record->request_piv_len);
-		print_interaction_field("req_kid  ", record->request_kid, record->request_kid_len);
-		PRINTF("   occupied : %s\n", record->is_occupied ? "true" : "false");
+		print_interaction_field("uri paths", record->uri_paths,
+					record->uri_paths_len);
+		print_interaction_field("token    ", record->token,
+					record->token_len);
+		print_interaction_field("req_piv  ", record->request_piv,
+					record->request_piv_len);
+		print_interaction_field("req_kid  ", record->request_kid,
+					record->request_kid_len);
+		PRINTF("   occupied : %s\n",
+		       record->is_occupied ? "true" : "false");
 	}
 }
 
 #define PRINT_INTERACTIONS(table) print_interactions(table)
 
 #else
-#define PRINT_INTERACTIONS(table) {}
+#define PRINT_INTERACTIONS(table)                                              \
+	{                                                                      \
+	}
 #endif
 
 /**
@@ -75,19 +82,16 @@ static void print_interactions(struct oscore_interaction_t * interactions)
  * @param expected_size Number of bytes to be compared.
  * @return True if memory buffers are identical, false otherwise.
  */
-static bool compare_memory(uint8_t * actual, uint32_t actual_size, uint8_t * expected, uint32_t expected_size)
+static bool compare_memory(uint8_t *actual, uint32_t actual_size,
+			   uint8_t *expected, uint32_t expected_size)
 {
-	if (actual_size != expected_size)
-	{
+	if (actual_size != expected_size) {
 		return false;
 	}
 
-	if ((NULL != actual) && (NULL != expected))
-	{
+	if ((NULL != actual) && (NULL != expected)) {
 		return (0 == memcmp(actual, expected, expected_size));
-	}
-	else if ((NULL == actual) && (0 == expected_size))
-	{
+	} else if ((NULL == actual) && (0 == expected_size)) {
 		return true;
 	}
 
@@ -99,13 +103,11 @@ static bool compare_memory(uint8_t * actual, uint32_t actual_size, uint8_t * exp
  * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
  * @return Index of the first unoccupied slot (or OSCORE_INTERACTIONS_COUNT if the array is full).
  */
-static uint32_t find_unoccupied_index(struct oscore_interaction_t * interactions)
+static uint32_t find_unoccupied_index(struct oscore_interaction_t *interactions)
 {
 	uint32_t index;
-	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
-	{
-		if (false == interactions[index].is_occupied)
-		{
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++) {
+		if (false == interactions[index].is_occupied) {
 			break;
 		}
 	}
@@ -120,16 +122,21 @@ static uint32_t find_unoccupied_index(struct oscore_interaction_t * interactions
  * @param request_type Request type to match.
  * @return Index of the record (of OSCORE_INTERACTIONS_COUNT if not found).
  */
-static uint32_t find_record_index_by_resource(struct oscore_interaction_t * interactions, uint8_t * uri_paths, uint8_t uri_paths_len, enum o_coap_msg request_type)
+static uint32_t
+find_record_index_by_resource(struct oscore_interaction_t *interactions,
+			      uint8_t *uri_paths, uint8_t uri_paths_len,
+			      enum o_coap_msg request_type)
 {
 	uint32_t index;
-	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
-	{
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++) {
 		bool is_occupied = interactions[index].is_occupied;
-		bool request_type_ok = (interactions[index].request_type == request_type);
-		bool uri_path_ok = compare_memory(uri_paths, uri_paths_len, interactions[index].uri_paths, interactions[index].uri_paths_len);
-		if (is_occupied && request_type_ok && uri_path_ok)
-		{
+		bool request_type_ok =
+			(interactions[index].request_type == request_type);
+		bool uri_path_ok =
+			compare_memory(uri_paths, uri_paths_len,
+				       interactions[index].uri_paths,
+				       interactions[index].uri_paths_len);
+		if (is_occupied && request_type_ok && uri_path_ok) {
 			break;
 		}
 	}
@@ -143,62 +150,69 @@ static uint32_t find_record_index_by_resource(struct oscore_interaction_t * inte
  * @param token_len Token buffer size.
  * @return Index of the record (if found), or OSCORE_INTERACTIONS_COUNT (if not found).
  */
-static uint32_t find_record_index_by_token(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len)
+static uint32_t
+find_record_index_by_token(struct oscore_interaction_t *interactions,
+			   uint8_t *token, uint8_t token_len)
 {
 	uint32_t index;
-	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
-	{
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++) {
 		bool is_occupied = interactions[index].is_occupied;
-		bool token_ok = compare_memory(token, token_len, interactions[index].token, interactions[index].token_len);
-		if (is_occupied && token_ok)
-		{
+		bool token_ok = compare_memory(token, token_len,
+					       interactions[index].token,
+					       interactions[index].token_len);
+		if (is_occupied && token_ok) {
 			break;
 		}
 	}
 	return index;
 }
 
-enum err oscore_interactions_init(struct oscore_interaction_t * interactions)
+enum err oscore_interactions_init(struct oscore_interaction_t *interactions)
 {
-	if (NULL == interactions)
-	{
+	if (NULL == interactions) {
 		return wrong_parameter;
 	}
 
-	memset(interactions, 0, sizeof(struct oscore_interaction_t)*OSCORE_INTERACTIONS_COUNT);
+	memset(interactions, 0,
+	       sizeof(struct oscore_interaction_t) * OSCORE_INTERACTIONS_COUNT);
 	return ok;
 }
 
-enum err oscore_interactions_set_record(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record)
+enum err
+oscore_interactions_set_record(struct oscore_interaction_t *interactions,
+			       struct oscore_interaction_t *record)
 {
-	if ((NULL == interactions) || (NULL == record) || \
-		(record->token_len > MAX_TOKEN_LEN) || (record->uri_paths_len > OSCORE_MAX_URI_PATH_LEN) || \
-		(record->request_piv_len > MAX_PIV_LEN) || (record->request_kid_len > MAX_KID_LEN))
-	{
+	if ((NULL == interactions) || (NULL == record) ||
+	    (record->token_len > MAX_TOKEN_LEN) ||
+	    (record->uri_paths_len > OSCORE_MAX_URI_PATH_LEN) ||
+	    (record->request_piv_len > MAX_PIV_LEN) ||
+	    (record->request_kid_len > MAX_KID_LEN)) {
 		return wrong_parameter;
 	}
 
 	// Find the entry at which the record will be stored.
-	uint32_t index_by_uri = find_record_index_by_resource(interactions, record->uri_paths, record->uri_paths_len, record->request_type);
-	if (index_by_uri >= OSCORE_INTERACTIONS_COUNT)
-	{
+	uint32_t index_by_uri =
+		find_record_index_by_resource(interactions, record->uri_paths,
+					      record->uri_paths_len,
+					      record->request_type);
+	if (index_by_uri >= OSCORE_INTERACTIONS_COUNT) {
 		index_by_uri = find_unoccupied_index(interactions);
-		if (index_by_uri >= OSCORE_INTERACTIONS_COUNT)
-		{
+		if (index_by_uri >= OSCORE_INTERACTIONS_COUNT) {
 			return oscore_max_interactions;
 		}
 	}
 
 	// Prevent from using the same token twice, as it would be impossible to find the proper record with get_record.
-	uint32_t index_by_token = find_record_index_by_token(interactions, record->token, record->token_len);
-	if ((index_by_token < OSCORE_INTERACTIONS_COUNT) && (index_by_token != index_by_uri))
-	{
+	uint32_t index_by_token = find_record_index_by_token(
+		interactions, record->token, record->token_len);
+	if ((index_by_token < OSCORE_INTERACTIONS_COUNT) &&
+	    (index_by_token != index_by_uri)) {
 		PRINTF(msg_token_already_used, index_by_token);
 		return oscore_interaction_duplicated_token;
 	}
 
 	record->is_occupied = true;
-	
+
 	// Memmove is used to avoid overlapping issues when get_record output is used as the record.
 	memmove(&interactions[index_by_uri], record, sizeof(*record));
 	PRINT_MSG("set record:\n");
@@ -206,10 +220,13 @@ enum err oscore_interactions_set_record(struct oscore_interaction_t * interactio
 	return ok;
 }
 
-enum err oscore_interactions_get_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, struct oscore_interaction_t ** record)
+enum err
+oscore_interactions_get_record(struct oscore_interaction_t *interactions,
+			       uint8_t *token, uint8_t token_len,
+			       struct oscore_interaction_t **record)
 {
-	if ((NULL == interactions) || (NULL == record) || (token_len > MAX_TOKEN_LEN))
-	{
+	if ((NULL == interactions) || (NULL == record) ||
+	    (token_len > MAX_TOKEN_LEN)) {
 		return wrong_parameter;
 	}
 	*record = NULL;
@@ -217,9 +234,9 @@ enum err oscore_interactions_get_record(struct oscore_interaction_t * interactio
 	PRINT_MSG("get record:\n");
 	PRINT_INTERACTIONS(interactions);
 
-	uint32_t index = find_record_index_by_token(interactions, token, token_len);
-	if (index >= OSCORE_INTERACTIONS_COUNT)
-	{
+	uint32_t index =
+		find_record_index_by_token(interactions, token, token_len);
+	if (index >= OSCORE_INTERACTIONS_COUNT) {
 		PRINT_MSG(msg_interaction_not_found);
 		PRINT_ARRAY("token", token, token_len);
 		return oscore_interaction_not_found;
@@ -229,19 +246,20 @@ enum err oscore_interactions_get_record(struct oscore_interaction_t * interactio
 	return ok;
 }
 
-enum err oscore_interactions_remove_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len)
+enum err
+oscore_interactions_remove_record(struct oscore_interaction_t *interactions,
+				  uint8_t *token, uint8_t token_len)
 {
-	if ((NULL == interactions) || (token_len > MAX_TOKEN_LEN))
-	{
+	if ((NULL == interactions) || (token_len > MAX_TOKEN_LEN)) {
 		return wrong_parameter;
 	}
 
 	PRINT_MSG("remove record (before):\n");
 	PRINT_INTERACTIONS(interactions);
 
-	uint32_t index = find_record_index_by_token(interactions, token, token_len);
-	if (index >= OSCORE_INTERACTIONS_COUNT)
-	{
+	uint32_t index =
+		find_record_index_by_token(interactions, token, token_len);
+	if (index >= OSCORE_INTERACTIONS_COUNT) {
 		PRINT_MSG(msg_interaction_not_found);
 		PRINT_ARRAY("token", token, token_len);
 		return oscore_interaction_not_found;
@@ -253,18 +271,22 @@ enum err oscore_interactions_remove_record(struct oscore_interaction_t * interac
 	return ok;
 }
 
-enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid)
+enum err oscore_interactions_read_wrapper(
+	enum o_coap_msg msg_type, struct byte_array *token,
+	struct oscore_interaction_t *interactions,
+	struct byte_array *request_piv, struct byte_array *request_kid)
 {
-	if ((NULL == token) || (NULL == interactions) || (NULL == request_piv) || (NULL == request_kid))
-	{
+	if ((NULL == token) || (NULL == interactions) ||
+	    (NULL == request_piv) || (NULL == request_kid)) {
 		return wrong_parameter;
 	}
 
-	if ((COAP_MSG_RESPONSE == msg_type) || (COAP_MSG_NOTIFICATION == msg_type))
-	{
+	if ((COAP_MSG_RESPONSE == msg_type) ||
+	    (COAP_MSG_NOTIFICATION == msg_type)) {
 		/* Server sends / Client receives any response (notification included) - read the record from interactions array and update request_piv and request_kid. */
 		struct oscore_interaction_t *record;
-		TRY(oscore_interactions_get_record(interactions, token->ptr, token->len, &record));
+		TRY(oscore_interactions_get_record(interactions, token->ptr,
+						   token->len, &record));
 		request_piv->ptr = record->request_piv;
 		request_piv->len = record->request_piv_len;
 		request_kid->ptr = record->request_kid;
@@ -274,21 +296,23 @@ enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_
 	return ok;
 }
 
-enum err oscore_interactions_update_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct byte_array *uri_paths, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid)
+enum err oscore_interactions_update_wrapper(
+	enum o_coap_msg msg_type, struct byte_array *token,
+	struct byte_array *uri_paths, struct oscore_interaction_t *interactions,
+	struct byte_array *request_piv, struct byte_array *request_kid)
 {
-	if ((NULL == token) || (NULL == uri_paths) || (NULL == interactions) || (NULL == request_piv) || (NULL == request_kid))
-	{
+	if ((NULL == token) || (NULL == uri_paths) || (NULL == interactions) ||
+	    (NULL == request_piv) || (NULL == request_kid)) {
 		return wrong_parameter;
 	}
 
 	// cancellation must be interpreted as a registration, to properly match the corresponding record from the interactions table.
-	if (COAP_MSG_CANCELLATION == msg_type)
-	{
+	if (COAP_MSG_CANCELLATION == msg_type) {
 		msg_type = COAP_MSG_REGISTRATION;
 	}
 
-	if ((COAP_MSG_REQUEST == msg_type) || (COAP_MSG_REGISTRATION == msg_type))
-	{
+	if ((COAP_MSG_REQUEST == msg_type) ||
+	    (COAP_MSG_REGISTRATION == msg_type)) {
 		/* Server receives / client sends any request (including registration and cancellation) - add the record to the interactions array.
 		   Request_piv and request_kid not updated - current values of PIV and KID (Sender ID) are used. */
 		struct oscore_interaction_t record = {
@@ -298,17 +322,20 @@ enum err oscore_interactions_update_wrapper(enum o_coap_msg msg_type, struct byt
 			.uri_paths_len = uri_paths->len,
 			.request_type = msg_type
 		};
-		TRY(_memcpy_s(record.request_piv, MAX_PIV_LEN, request_piv->ptr, request_piv->len));
-		TRY(_memcpy_s(record.request_kid, MAX_KID_LEN, request_kid->ptr, request_kid->len));
-		TRY(_memcpy_s(record.token, MAX_TOKEN_LEN, token->ptr, token->len));
-		TRY(_memcpy_s(record.uri_paths, OSCORE_MAX_URI_PATH_LEN, uri_paths->ptr, uri_paths->len));
+		TRY(_memcpy_s(record.request_piv, MAX_PIV_LEN, request_piv->ptr,
+			      request_piv->len));
+		TRY(_memcpy_s(record.request_kid, MAX_KID_LEN, request_kid->ptr,
+			      request_kid->len));
+		TRY(_memcpy_s(record.token, MAX_TOKEN_LEN, token->ptr,
+			      token->len));
+		TRY(_memcpy_s(record.uri_paths, OSCORE_MAX_URI_PATH_LEN,
+			      uri_paths->ptr, uri_paths->len));
 		TRY(oscore_interactions_set_record(interactions, &record));
-	}
-	else if (COAP_MSG_RESPONSE == msg_type)
-	{
+	} else if (COAP_MSG_RESPONSE == msg_type) {
 		/* Server sends / client receives a regular response - remove the record. */
 		//TODO removing records must be taken into account when No-Response support will be added.
-		TRY(oscore_interactions_remove_record(interactions, token->ptr, token->len));
+		TRY(oscore_interactions_remove_record(interactions, token->ptr,
+						      token->len));
 	}
 
 	return ok;

--- a/src/oscore/oscore_interactions.c
+++ b/src/oscore/oscore_interactions.c
@@ -1,0 +1,315 @@
+/*
+   Copyright (c) 2023 Assa Abloy. See the COPYRIGHT
+   file at the top-level directory of this distribution.
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "oscore/oscore_interactions.h"
+#include "common/byte_array.h"
+#include "common/print_util.h"
+
+#ifdef DEBUG_PRINT
+static const char msg_interaction_not_found[] = "Couldn't find the interaction with given key.\n";
+static const char msg_token_already_used[] = "Given token is already used by other interaction (index=%u).\n";
+
+/**
+ * @brief Print single interaction field.
+ * 
+ * @param msg Field name, null char included.
+ * @param buffer Field buffer.
+ * @param len Buffer size in bytes.
+ */
+static void print_interaction_field(const char * name, uint8_t * buffer, uint32_t len)
+{
+	PRINTF("   %s: ", name);
+	if (NULL != buffer)
+	{
+		for (uint32_t index = 0; index < len; index++)
+		{
+			PRINTF("%02x ", buffer[index]);
+		}
+	}
+	PRINTF("\n");
+}
+
+/**
+ * @brief Print interactions array.
+ * 
+ * @param interactions Input interactions array.
+ */
+static void print_interactions(struct oscore_interaction_t * interactions)
+{
+	for (uint8_t index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
+	{
+		struct oscore_interaction_t *record = &interactions[index];
+		PRINTF("record %02u:\n", index);
+		PRINTF("   type     : %d\n", record->request_type);
+		print_interaction_field("uri paths", record->uri_paths, record->uri_paths_len);
+		print_interaction_field("token    ", record->token, record->token_len);
+		print_interaction_field("req_piv  ", record->request_piv, record->request_piv_len);
+		print_interaction_field("req_kid  ", record->request_kid, record->request_kid_len);
+		PRINTF("   occupied : %s\n", record->is_occupied ? "true" : "false");
+	}
+}
+
+#define PRINT_INTERACTIONS(table) print_interactions(table)
+
+#else
+#define PRINT_INTERACTIONS(table) {}
+#endif
+
+/**
+ * @brief Securely compares two memory buffers.
+ * 
+ * @param actual Actual value.
+ * @param expected Expected value.
+ * @param expected_size Number of bytes to be compared.
+ * @return True if memory buffers are identical, false otherwise.
+ */
+static bool compare_memory(uint8_t * actual, uint32_t actual_size, uint8_t * expected, uint32_t expected_size)
+{
+	if (actual_size != expected_size)
+	{
+		return false;
+	}
+
+	if ((NULL != actual) && (NULL != expected))
+	{
+		return (0 == memcmp(actual, expected, expected_size));
+	}
+	else if ((NULL == actual) && (0 == expected_size))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Searches given interactions array for a first free slot.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @return Index of the first unoccupied slot (or OSCORE_INTERACTIONS_COUNT if the array is full).
+ */
+static uint32_t find_unoccupied_index(struct oscore_interaction_t * interactions)
+{
+	uint32_t index;
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
+	{
+		if (false == interactions[index].is_occupied)
+		{
+			break;
+		}
+	}
+	return index;
+}
+
+/**
+ * @brief Searches given interactions array for a record that matches given resource and request type.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param uri_paths Resource path buffer to match.
+ * @param uri_paths_len Resource path buffer size.
+ * @param request_type Request type to match.
+ * @return Index of the record (of OSCORE_INTERACTIONS_COUNT if not found).
+ */
+static uint32_t find_record_index_by_resource(struct oscore_interaction_t * interactions, uint8_t * uri_paths, uint8_t uri_paths_len, enum o_coap_msg request_type)
+{
+	uint32_t index;
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
+	{
+		bool is_occupied = interactions[index].is_occupied;
+		bool request_type_ok = (interactions[index].request_type == request_type);
+		bool uri_path_ok = compare_memory(uri_paths, uri_paths_len, interactions[index].uri_paths, interactions[index].uri_paths_len);
+		if (is_occupied && request_type_ok && uri_path_ok)
+		{
+			break;
+		}
+	}
+	return index;
+}
+
+/**
+ * @brief Searches given interactions array for a record that matches given token.
+ * @param interactions Interactions array, MUST have exactly OSCORE_INTERACTIONS_COUNT elements.
+ * @param token Token buffer to match.
+ * @param token_len Token buffer size.
+ * @return Index of the record (if found), or OSCORE_INTERACTIONS_COUNT (if not found).
+ */
+static uint32_t find_record_index_by_token(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len)
+{
+	uint32_t index;
+	for (index = 0; index < OSCORE_INTERACTIONS_COUNT; index++)
+	{
+		bool is_occupied = interactions[index].is_occupied;
+		bool token_ok = compare_memory(token, token_len, interactions[index].token, interactions[index].token_len);
+		if (is_occupied && token_ok)
+		{
+			break;
+		}
+	}
+	return index;
+}
+
+enum err oscore_interactions_init(struct oscore_interaction_t * interactions)
+{
+	if (NULL == interactions)
+	{
+		return wrong_parameter;
+	}
+
+	memset(interactions, 0, sizeof(struct oscore_interaction_t)*OSCORE_INTERACTIONS_COUNT);
+	return ok;
+}
+
+enum err oscore_interactions_set_record(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record)
+{
+	if ((NULL == interactions) || (NULL == record) || \
+		(record->token_len > MAX_TOKEN_LEN) || (record->uri_paths_len > OSCORE_MAX_URI_PATH_LEN) || \
+		(record->request_piv_len > MAX_PIV_LEN) || (record->request_kid_len > MAX_KID_LEN))
+	{
+		return wrong_parameter;
+	}
+
+	// Find the entry at which the record will be stored.
+	uint32_t index_by_uri = find_record_index_by_resource(interactions, record->uri_paths, record->uri_paths_len, record->request_type);
+	if (index_by_uri >= OSCORE_INTERACTIONS_COUNT)
+	{
+		index_by_uri = find_unoccupied_index(interactions);
+		if (index_by_uri >= OSCORE_INTERACTIONS_COUNT)
+		{
+			return oscore_max_interactions;
+		}
+	}
+
+	// Prevent from using the same token twice, as it would be impossible to find the proper record with get_record.
+	uint32_t index_by_token = find_record_index_by_token(interactions, record->token, record->token_len);
+	if ((index_by_token < OSCORE_INTERACTIONS_COUNT) && (index_by_token != index_by_uri))
+	{
+		PRINTF(msg_token_already_used, index_by_token);
+		return oscore_interaction_duplicated_token;
+	}
+
+	record->is_occupied = true;
+	
+	// Memmove is used to avoid overlapping issues when get_record output is used as the record.
+	memmove(&interactions[index_by_uri], record, sizeof(*record));
+	PRINT_MSG("set record:\n");
+	PRINT_INTERACTIONS(interactions);
+	return ok;
+}
+
+enum err oscore_interactions_get_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, struct oscore_interaction_t ** record)
+{
+	if ((NULL == interactions) || (NULL == record) || (token_len > MAX_TOKEN_LEN))
+	{
+		return wrong_parameter;
+	}
+	*record = NULL;
+
+	PRINT_MSG("get record:\n");
+	PRINT_INTERACTIONS(interactions);
+
+	uint32_t index = find_record_index_by_token(interactions, token, token_len);
+	if (index >= OSCORE_INTERACTIONS_COUNT)
+	{
+		PRINT_MSG(msg_interaction_not_found);
+		PRINT_ARRAY("token", token, token_len);
+		return oscore_interaction_not_found;
+	}
+
+	*record = &interactions[index];
+	return ok;
+}
+
+enum err oscore_interactions_remove_record(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len)
+{
+	if ((NULL == interactions) || (token_len > MAX_TOKEN_LEN))
+	{
+		return wrong_parameter;
+	}
+
+	PRINT_MSG("remove record (before):\n");
+	PRINT_INTERACTIONS(interactions);
+
+	uint32_t index = find_record_index_by_token(interactions, token, token_len);
+	if (index >= OSCORE_INTERACTIONS_COUNT)
+	{
+		PRINT_MSG(msg_interaction_not_found);
+		PRINT_ARRAY("token", token, token_len);
+		return oscore_interaction_not_found;
+	}
+
+	memset(&interactions[index], 0, sizeof(struct oscore_interaction_t));
+	PRINT_MSG("remove record (after):\n");
+	PRINT_INTERACTIONS(interactions);
+	return ok;
+}
+
+enum err oscore_interactions_read_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid)
+{
+	if ((NULL == token) || (NULL == interactions) || (NULL == request_piv) || (NULL == request_kid))
+	{
+		return wrong_parameter;
+	}
+
+	if ((COAP_MSG_RESPONSE == msg_type) || (COAP_MSG_NOTIFICATION == msg_type))
+	{
+		/* Server sends / Client receives any response (notification included) - read the record from interactions array and update request_piv and request_kid. */
+		struct oscore_interaction_t *record;
+		TRY(oscore_interactions_get_record(interactions, token->ptr, token->len, &record));
+		request_piv->ptr = record->request_piv;
+		request_piv->len = record->request_piv_len;
+		request_kid->ptr = record->request_kid;
+		request_kid->len = record->request_kid_len;
+	}
+
+	return ok;
+}
+
+enum err oscore_interactions_update_wrapper(enum o_coap_msg msg_type, struct byte_array *token, struct byte_array *uri_paths, struct oscore_interaction_t *interactions, struct byte_array *request_piv, struct byte_array *request_kid)
+{
+	if ((NULL == token) || (NULL == uri_paths) || (NULL == interactions) || (NULL == request_piv) || (NULL == request_kid))
+	{
+		return wrong_parameter;
+	}
+
+	// cancellation must be interpreted as a registration, to properly match the corresponding record from the interactions table.
+	if (COAP_MSG_CANCELLATION == msg_type)
+	{
+		msg_type = COAP_MSG_REGISTRATION;
+	}
+
+	if ((COAP_MSG_REQUEST == msg_type) || (COAP_MSG_REGISTRATION == msg_type))
+	{
+		/* Server receives / client sends any request (including registration and cancellation) - add the record to the interactions array.
+		   Request_piv and request_kid not updated - current values of PIV and KID (Sender ID) are used. */
+		struct oscore_interaction_t record = {
+			.request_piv_len = request_piv->len,
+			.request_kid_len = request_kid->len,
+			.token_len = token->len,
+			.uri_paths_len = uri_paths->len,
+			.request_type = msg_type
+		};
+		TRY(_memcpy_s(record.request_piv, MAX_PIV_LEN, request_piv->ptr, request_piv->len));
+		TRY(_memcpy_s(record.request_kid, MAX_KID_LEN, request_kid->ptr, request_kid->len));
+		TRY(_memcpy_s(record.token, MAX_TOKEN_LEN, token->ptr, token->len));
+		TRY(_memcpy_s(record.uri_paths, OSCORE_MAX_URI_PATH_LEN, uri_paths->ptr, uri_paths->len));
+		TRY(oscore_interactions_set_record(interactions, &record));
+	}
+	else if (COAP_MSG_RESPONSE == msg_type)
+	{
+		/* Server sends / client receives a regular response - remove the record. */
+		//TODO removing records must be taken into account when No-Response support will be added.
+		TRY(oscore_interactions_remove_record(interactions, token->ptr, token->len));
+	}
+
+	return ok;
+}

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -141,11 +141,9 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	c->sc.sender_id = params->sender_id;
 	c->sc.sender_key.len = sizeof(c->sc.sender_key_buf);
 	c->sc.sender_key.ptr = c->sc.sender_key_buf;
-	struct nvm_key_t nvm_key = {
-		.sender_id = c->sc.sender_id,
-		.recipient_id = c->rc.recipient_id,
-		.id_context = c->cc.id_context
-	};
+	struct nvm_key_t nvm_key = { .sender_id = c->sc.sender_id,
+				     .recipient_id = c->rc.recipient_id,
+				     .id_context = c->cc.id_context };
 
 	TRY(ssn_init(&nvm_key, &c->sc.ssn, params->fresh_master_secret_salt));
 	TRY(derive_sender_key(&c->cc, &c->sc));
@@ -158,24 +156,25 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	c->rrc.echo_opt_val.ptr = c->rrc.echo_opt_val_buf;
 
 	/* no ECHO challenge needed if the context is fresh */
-	c->rrc.echo_state_machine = (params->fresh_master_secret_salt ? ECHO_SYNCHRONIZED : ECHO_REBOOT);
-	
+	c->rrc.echo_state_machine =
+		(params->fresh_master_secret_salt ? ECHO_SYNCHRONIZED :
+						    ECHO_REBOOT);
+
 	return ok;
 }
 
 enum err check_context_freshness(struct context *c)
 {
-	if (NULL == c)
-	{
+	if (NULL == c) {
 		return wrong_parameter;
 	}
 
 	/* "If the Sender Sequence Number exceeds the maximum, the endpoint MUST NOT
 	   process any more messages with the given Sender Context."
 	   For more info, refer to RFC 8613 p. 7.2.1. */
-	if (c->sc.ssn >= OSCORE_SSN_OVERFLOW_VALUE )
-	{
-		PRINT_MSG("Sender Sequence Number reached its limit. New security context must be established.\n");
+	if (c->sc.ssn >= OSCORE_SSN_OVERFLOW_VALUE) {
+		PRINT_MSG(
+			"Sender Sequence Number reached its limit. New security context must be established.\n");
 		return oscore_ssn_overflow;
 	}
 	return ok;
@@ -183,7 +182,8 @@ enum err check_context_freshness(struct context *c)
 
 enum err ssn2piv(uint64_t ssn, struct byte_array *piv)
 {
-	if ((NULL == piv) || (NULL == piv->ptr) || (ssn > MAX_PIV_FIELD_VALUE)) {
+	if ((NULL == piv) || (NULL == piv->ptr) ||
+	    (ssn > MAX_PIV_FIELD_VALUE)) {
 		return wrong_parameter;
 	}
 
@@ -199,10 +199,9 @@ enum err ssn2piv(uint64_t ssn, struct byte_array *piv)
 		//if the sender seq number is 0 piv has value 0 and length 1
 		piv->ptr[0] = 0;
 		piv->len = 1;
-	}
-	else {
+	} else {
 		//PIV is encoded in big endian
-		for (uint8_t pos=0; pos<len; pos++) {
+		for (uint8_t pos = 0; pos < len; pos++) {
 			piv->ptr[pos] = tmp_piv[len - 1 - pos];
 		}
 		piv->len = len;
@@ -218,17 +217,16 @@ enum err piv2ssn(struct byte_array *piv, uint64_t *ssn)
 
 	uint8_t *value = piv->ptr;
 	uint32_t len = piv->len;
-	if (len > MAX_PIV_LEN)
-	{
+	if (len > MAX_PIV_LEN) {
 		return wrong_parameter;
 	}
 
 	uint64_t result = 0;
-	if (NULL != value)
-	{
+	if (NULL != value) {
 		//PIV is encoded in big endian
 		for (uint32_t pos = 0; pos < len; pos++) {
-			result += (uint64_t)(value[pos]) << (8 * (len - 1 - pos));
+			result += (uint64_t)(value[pos])
+				  << (8 * (len - 1 - pos));
 		}
 	}
 	*ssn = result;

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -19,6 +19,7 @@
 #include "oscore/nonce.h"
 #include "oscore/oscore_coap.h"
 #include "oscore/oscore_hkdf_info.h"
+#include "oscore/oscore_interactions.h"
 #include "oscore/security_context.h"
 #include "oscore/nvm.h"
 
@@ -150,27 +151,15 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	TRY(derive_sender_key(&c->cc, &c->sc));
 
 	/*set up the request response context**********************************/
+	oscore_interactions_init(c->rrc.interactions);
 	c->rrc.nonce.len = sizeof(c->rrc.nonce_buf);
 	c->rrc.nonce.ptr = c->rrc.nonce_buf;
-	c->rrc.request_kid.len = sizeof(c->rrc.request_kid_buf);
-	c->rrc.request_kid.ptr = c->rrc.request_kid_buf;
-	c->rrc.request_piv.len = sizeof(c->rrc.request_piv_buf);
-	c->rrc.request_piv.ptr = c->rrc.request_piv_buf;
 	c->rrc.echo_opt_val.len = sizeof(c->rrc.echo_opt_val_buf);
 	c->rrc.echo_opt_val.ptr = c->rrc.echo_opt_val_buf;
 
 	/* no ECHO challenge needed if the context is fresh */
 	c->rrc.echo_state_machine = (params->fresh_master_secret_salt ? ECHO_SYNCHRONIZED : ECHO_REBOOT);
 	
-	return ok;
-}
-
-enum err update_request_piv_request_kid(struct context *c,
-					struct byte_array *piv,
-					struct byte_array *kid)
-{
-	TRY(byte_array_cpy(&c->rrc.request_kid, kid, MAX_KID_LEN));
-	TRY(byte_array_cpy(&c->rrc.request_piv, piv, MAX_PIV_LEN));
 	return ok;
 }
 

--- a/test/main.c
+++ b/test/main.c
@@ -161,6 +161,7 @@ void test_main(void)
 		ztest_unit_test(t200_options_serialize_deserialize),
 		ztest_unit_test(t201_coap_serialize_deserialize),
 		ztest_unit_test(t202_options_deserialize_corner_cases),
+		ztest_unit_test(t203_coap_get_message_type),
 		ztest_unit_test(t300_oscore_option_parser_no_piv),
 		ztest_unit_test(t301_oscore_option_parser_wrong_n),
 		ztest_unit_test(t302_oscore_option_parser_no_kid),
@@ -168,6 +169,8 @@ void test_main(void)
 		ztest_unit_test(t400_is_class_e),
 		ztest_unit_test(t401_cache_echo_val),
 		ztest_unit_test(t402_echo_val_is_fresh),
+		ztest_unit_test(t403_uri_path_create),
+		ztest_unit_test(t404_get_observe_value),
 		ztest_unit_test(t500_oscore_context_init_corner_cases),
 		ztest_unit_test(t501_piv2ssn),
 		ztest_unit_test(t502_ssn2piv),
@@ -179,7 +182,13 @@ void test_main(void)
 		ztest_unit_test(t603_server_replay_check_in_progress_test),
 		ztest_unit_test(t604_server_replay_insert_zero_test),
 		ztest_unit_test(t605_server_replay_insert_test),
-		ztest_unit_test(t606_server_replay_standard_scenario_test));
+		ztest_unit_test(t606_server_replay_standard_scenario_test),
+		ztest_unit_test(t700_interactions_init_test),
+		ztest_unit_test(t701_interactions_set_record_test),
+		ztest_unit_test(t702_interactions_get_record_test),
+		ztest_unit_test(t703_interactions_remove_record_test),
+		ztest_unit_test(t704_interactions_usecases_test)
+		);
 
 	ztest_run_test_suite(exporter);
 	ztest_run_test_suite(initiator_responder_interaction);

--- a/test/oscore_tests.h
+++ b/test/oscore_tests.h
@@ -35,6 +35,7 @@ void t106_oscore_option_generate_no_piv(void);
 void t200_options_serialize_deserialize(void);
 void t201_coap_serialize_deserialize(void);
 void t202_options_deserialize_corner_cases(void);
+void t203_coap_get_message_type(void);
 
 void t300_oscore_option_parser_no_piv(void);
 void t301_oscore_option_parser_wrong_n(void);
@@ -44,6 +45,8 @@ void t303_options_reorder(void);
 void t400_is_class_e(void);
 void t401_cache_echo_val(void);
 void t402_echo_val_is_fresh(void);
+void t403_uri_path_create(void);
+void t404_get_observe_value(void);
 
 void t500_oscore_context_init_corner_cases(void);
 void t501_piv2ssn(void);
@@ -58,5 +61,11 @@ void t603_server_replay_check_in_progress_test(void);
 void t604_server_replay_insert_zero_test(void);
 void t605_server_replay_insert_test(void);
 void t606_server_replay_standard_scenario_test(void);
+
+void t700_interactions_init_test(void);
+void t701_interactions_set_record_test(void);
+void t702_interactions_get_record_test(void);
+void t703_interactions_remove_record_test(void);
+void t704_interactions_usecases_test(void);
 
 #endif

--- a/test/oscore_unit_tests/unit_test_option.c
+++ b/test/oscore_unit_tests/unit_test_option.c
@@ -11,9 +11,39 @@
 
 #include <zephyr/zephyr.h>
 #include <zephyr/ztest.h>
+#include <string.h>
 
 #include "oscore/option.h"
 #include "common/byte_array.h"
+
+#define GET_ARRAY_SIZE(_array) (sizeof(_array) / sizeof(_array[0]))
+
+static void uri_path_create_and_expect(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size, enum err expected_result)
+{
+	PRINTF("uri_path_create; expected result = %d\n", expected_result);
+	enum err result = uri_path_create(options, options_size, uri_path, uri_path_size);
+	zassert_equal(expected_result, result, "unexpected result: %d", result);
+}
+
+static void uri_path_create_and_compare(struct o_coap_option *options, uint32_t options_size, uint8_t * uri_path, uint32_t * uri_path_size, enum err expected_result, uint8_t * expected_uri_path, uint32_t expected_uri_path_size)
+{
+	uri_path_create_and_expect(options, options_size, uri_path, uri_path_size, expected_result);
+	zassert_equal(expected_uri_path_size, *uri_path_size, "unexpected output size: %d", *uri_path_size);
+	zassert_mem_equal(expected_uri_path, uri_path, expected_uri_path_size, "");
+	*uri_path_size = OSCORE_MAX_URI_PATH_LEN; //restore valid buffer size (cleanup for next calls).
+}
+
+static void get_observe_value_and_compare(struct o_coap_option *options, uint8_t options_cnt, struct byte_array * output, bool expected_result, struct byte_array * expected_output)
+{
+	PRINTF("get_observe_value; expected result = %d\n", expected_result);
+	bool result = get_observe_value(options, options_cnt, output);
+	zassert_equal(expected_result, result, "unexpected result: %d", result);
+
+	if (NULL != expected_output)
+	{
+		zassert_equal(true, array_equals(output, expected_output), "");
+	}
+}
 
 void t400_is_class_e(void)
 {
@@ -78,4 +108,107 @@ void t402_echo_val_is_fresh(void)
 	r = echo_val_is_fresh(&cache_val, &decrypted_payload_mismatch);
 	zassert_equal(r, echo_val_mismatch, "Error in echo_val_is_fresh. r: %d",
 		      r);
+}
+
+void t403_uri_path_create(void)
+{
+	struct o_coap_option default_options[] = {
+		{ .option_number = IF_NONE_MATCH },
+		{ .option_number = URI_PATH, .value = "path", .len = 4 },
+		{ .option_number = URI_PATH, .value = "to", .len = 2 },
+		{ .option_number = OSCORE },
+		{ .option_number = URI_PATH, .value = "rsc", .len = 3 },
+	};
+	uint32_t default_size = GET_ARRAY_SIZE(default_options);
+	uint8_t expected_default_path[] = "path/to/rsc";
+	
+	uint8_t output_buffer[OSCORE_MAX_URI_PATH_LEN];
+	uint32_t output_buffer_size = sizeof(output_buffer);
+
+	/* Test null pointers. */
+	uri_path_create_and_expect(NULL, default_size, output_buffer, &output_buffer_size, wrong_parameter);
+	uri_path_create_and_expect(default_options, default_size, NULL, &output_buffer_size, wrong_parameter);
+	uri_path_create_and_expect(default_options, default_size, output_buffer, NULL, wrong_parameter);
+
+	/* Test too small output buffer. */
+	uint32_t wrong_output_size = 2; //should fail while adding first element
+	uri_path_create_and_expect(default_options, default_size, output_buffer, &wrong_output_size, buffer_to_small);
+	wrong_output_size = 4; //should fail while adding '/' after first element
+	uri_path_create_and_expect(default_options, default_size, output_buffer, &wrong_output_size, buffer_to_small);
+	wrong_output_size = 10; //should fail while adding last element
+	uri_path_create_and_expect(default_options, default_size, output_buffer, &wrong_output_size, buffer_to_small);
+
+	/* Wrong option should fail. */
+	struct o_coap_option wrong_option[] = {
+		{ .option_number = MAX_AGE },
+		{ .option_number = URI_PATH, .value = "path", .len = 4 },
+		{ .option_number = URI_PATH, .value = NULL, .len = 2 },
+		{ .option_number = OSCORE },
+		{ .option_number = URI_PATH, .value = "rsc", .len = 3 },
+	};
+	uint32_t wrong_size = GET_ARRAY_SIZE(wrong_option);
+	uri_path_create_and_expect(wrong_option, wrong_size, output_buffer, &output_buffer_size, oscore_wrong_uri_path);
+
+	/* Valid data should pass. */
+	uri_path_create_and_compare(default_options, default_size, output_buffer, &output_buffer_size, ok, expected_default_path, strlen(expected_default_path));
+
+	/* Empty option should pass. */
+	struct o_coap_option empty_option[] = {
+		{ .option_number = MAX_AGE },
+		{ .option_number = URI_PATH, .value = "path", .len = 4 },
+		{ .option_number = URI_PATH, .value = NULL, .len = 0 },
+		{ .option_number = OSCORE },
+		{ .option_number = URI_PATH, .value = "rsc", .len = 3 },
+	};
+	uint32_t empty_size = GET_ARRAY_SIZE(empty_option);
+	uint8_t expected_empty_path[] = "path//rsc";
+	uri_path_create_and_compare(empty_option, empty_size, output_buffer, &output_buffer_size, ok, expected_empty_path, strlen(expected_empty_path));
+	
+	/* No URI-Path option should pass. */
+	struct o_coap_option no_options[] = {	
+		{ .option_number = MAX_AGE },
+		{ .option_number = OSCORE },
+	};
+	uint32_t no_options_size = GET_ARRAY_SIZE(no_options);
+	uint8_t expected_no_options_path[] = "/";
+	uri_path_create_and_compare(no_options, no_options_size, output_buffer, &output_buffer_size, ok, expected_no_options_path, strlen(expected_no_options_path));
+}
+
+void t404_get_observe_value(void)
+{
+	struct o_coap_option options_default[] = {
+		{ .option_number = IF_NONE_MATCH },
+		{ .option_number = OSCORE },
+		{ .option_number = OBSERVE, .value = "\x00", .len = 1 },
+	};
+	struct o_coap_option options_long_observe[] = {
+		{ .option_number = IF_NONE_MATCH },
+		{ .option_number = OSCORE },
+		{ .option_number = OBSERVE, .value = "\x00\x01\x02\x04", .len = 4 },
+	};
+	struct o_coap_option options_empty_observe[] = {
+		{ .option_number = IF_NONE_MATCH },
+		{ .option_number = OSCORE },
+		{ .option_number = OBSERVE },
+	};
+	struct o_coap_option options_no_observe[] = {
+		{ .option_number = IF_NONE_MATCH },
+		{ .option_number = OSCORE },
+	};
+
+	/* Test null pointers. */
+	struct byte_array output = BYTE_ARRAY_INIT(NULL, 0);
+	get_observe_value_and_compare(NULL, 0, &output, false, NULL);
+	get_observe_value_and_compare(options_default, 0, NULL, false, NULL);
+
+	/* Test different valid values of the OBSERVE option. */
+	struct byte_array expected_default = BYTE_ARRAY_INIT("\x00", 1);
+	struct byte_array expected_long_observe = BYTE_ARRAY_INIT("\x00\x01\x02\x04", 4);
+	struct byte_array expected_empty_observe = BYTE_ARRAY_INIT(NULL, 0);
+	get_observe_value_and_compare(options_default, GET_ARRAY_SIZE(options_default), &output, true, &expected_default);
+	get_observe_value_and_compare(options_long_observe, GET_ARRAY_SIZE(options_long_observe), &output, true, &expected_long_observe);
+	get_observe_value_and_compare(options_empty_observe, GET_ARRAY_SIZE(options_empty_observe), &output, true, &expected_empty_observe);
+
+	/* Test non-existing OBSERVE option. */
+	get_observe_value_and_compare(options_no_observe, GET_ARRAY_SIZE(options_no_observe), &output, false, NULL);
 }

--- a/test/oscore_unit_tests/unit_test_oscore_interactions.c
+++ b/test/oscore_unit_tests/unit_test_oscore_interactions.c
@@ -1,0 +1,315 @@
+/*
+   Copyright (c) 2023 Assa Abloy. See the COPYRIGHT
+   file at the top-level directory of this distribution.
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/ztest.h>
+
+#include "oscore/oscore_interactions.h"
+
+#define DUMMY_BYTE 10
+#define INTERACTIONS_ARRAY_SIZE (OSCORE_INTERACTIONS_COUNT * sizeof(struct oscore_interaction_t))
+
+#define URI_PATHS_DEFAULT "some/resource"
+#define TOKEN_DEFAULT "123456"
+
+#define URI_PATHS_2 (URI_PATHS_DEFAULT "2")
+#define TOKEN_2 (TOKEN_DEFAULT "7")
+
+static struct oscore_interaction_t default_record = 
+{
+	.token = TOKEN_DEFAULT,
+	.token_len = sizeof(TOKEN_DEFAULT),
+	.uri_paths = URI_PATHS_DEFAULT,
+	.uri_paths_len = sizeof(URI_PATHS_DEFAULT),
+	.request_piv = {0x01, 0x02, 0x03},
+	.request_piv_len = 3,
+	.request_kid = {0x10, 0x20},
+	.request_kid_len = 2,
+};
+
+/**
+ * @brief Call set_record and check its result.
+ */
+static void set_record_and_expect(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record, enum err expected_result)
+{
+	PRINTF("set_record; expected result = %d\n", expected_result);
+	enum err result = oscore_interactions_set_record(interactions, record);
+	zassert_equal(expected_result, result, "");
+}
+
+/**
+ * @brief Call set_record and compare resulting interactions array with expected data.
+ */
+static void set_record_and_compare(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record, enum err expected_result, struct oscore_interaction_t * expected_interactions)
+{
+	set_record_and_expect(interactions, record, expected_result);
+	zassert_mem_equal(interactions, expected_interactions, INTERACTIONS_ARRAY_SIZE, "");
+}
+
+/**
+ * @brief Call get_record and check its result. Pointer to resulting record will be written to given handle.
+ */
+static void get_record_and_expect(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, struct oscore_interaction_t ** record, enum err expected_result)
+{
+	PRINTF("get_record; expected result = %d\n", expected_result);
+	enum err result = oscore_interactions_get_record(interactions, token, token_len, record);
+	zassert_equal(expected_result, result, "");
+}
+
+/**
+ * @brief Call get_record and compare resulting record with expected data.
+ */
+static void get_record_and_compare(struct oscore_interaction_t * interactions, struct oscore_interaction_t * record)
+{
+	struct oscore_interaction_t * received_record;
+	get_record_and_expect(interactions, record->token, record->token_len, &received_record, ok);
+	zassert_mem_equal(received_record, record, sizeof(struct oscore_interaction_t), "");
+}
+
+/**
+ * @brief Call remove_record and check its result.
+ */
+static void remove_record_and_expect(struct oscore_interaction_t * interactions, uint8_t * token, uint8_t token_len, enum err expected_result)
+{
+	PRINTF("remove_record; expected result = %d\n", expected_result);
+	enum err result = oscore_interactions_remove_record(interactions, token, token_len);
+	zassert_equal(expected_result, result, "");
+}
+
+/**
+ * @brief Fill given interactions array with generated records, which will be additionally stored at records_array for later checks.
+ */
+static void generate_and_fill(struct oscore_interaction_t * interactions, struct oscore_interaction_t * records_array)
+{
+	oscore_interactions_init(interactions);
+	for (size_t entry = 0; entry < OSCORE_INTERACTIONS_COUNT; entry++)
+	{
+		struct oscore_interaction_t * record = &(records_array[entry]);
+		memcpy(record, &default_record, sizeof(struct oscore_interaction_t));
+		//adding one to make sure that only records other than the default one will be stored
+		record->uri_paths[0] += entry + 1;
+		record->token[0] += entry + 1;
+		record->request_piv[0] += entry;
+		record->request_kid[0] += entry;
+		set_record_and_expect(interactions, record, ok);
+	}
+}
+
+/**
+ * @brief Test interactions array initialization.
+ */
+void t700_interactions_init_test(void)
+{
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
+	struct oscore_interaction_t interactions_expected[OSCORE_INTERACTIONS_COUNT] = {0};
+
+	/* set random data to all fields */
+	memset(interactions, DUMMY_BYTE, INTERACTIONS_ARRAY_SIZE);
+
+	enum err result = oscore_interactions_init(NULL);
+	zassert_equal(wrong_parameter, result, "");
+
+	result = oscore_interactions_init(interactions);
+	zassert_equal(ok, result, "");
+	zassert_mem_equal(interactions, interactions_expected, INTERACTIONS_ARRAY_SIZE, "");
+}
+
+/**
+ * @brief Test setting the record into interactions array.
+ */
+void t701_interactions_set_record_test(void)
+{
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
+	oscore_interactions_init(interactions);
+
+	/* Test null pointers. */
+	set_record_and_expect(NULL, NULL, wrong_parameter);
+	set_record_and_expect(interactions, NULL, wrong_parameter);
+	set_record_and_expect(NULL, &default_record, wrong_parameter);
+
+	/* Test record with too big buffers. */
+	struct oscore_interaction_t wrong_record = default_record;
+	wrong_record.token_len = MAX_TOKEN_LEN + 1;
+	set_record_and_expect(interactions, &wrong_record, wrong_parameter);
+
+	wrong_record = default_record;
+	wrong_record.uri_paths_len = OSCORE_MAX_URI_PATH_LEN + 1;
+	set_record_and_expect(interactions, &wrong_record, wrong_parameter);
+
+	wrong_record = default_record;
+	wrong_record.request_piv_len = MAX_PIV_LEN + 1;
+	set_record_and_expect(interactions, &wrong_record, wrong_parameter);
+
+	wrong_record = default_record;
+	wrong_record.request_kid_len = MAX_KID_LEN + 1;
+	set_record_and_expect(interactions, &wrong_record, wrong_parameter);
+
+	/* Writing record to interactions array. */
+	struct oscore_interaction_t interactions_expected[OSCORE_INTERACTIONS_COUNT] = {0};
+	struct oscore_interaction_t record_1 = default_record;
+	interactions_expected[0] = record_1;
+	interactions_expected[0].is_occupied = true;
+	set_record_and_compare(interactions, &record_1, ok, interactions_expected);
+
+	/* Writing an existing record with the same data should change nothing. */
+	set_record_and_compare(interactions, &record_1, ok, interactions_expected);
+
+	/* Writing a record with different key (URI paths), but with already used token, should fail. */
+	struct oscore_interaction_t record_2 = default_record;
+	memcpy(record_2.uri_paths, URI_PATHS_2, sizeof(URI_PATHS_2));
+	record_2.uri_paths_len = sizeof(URI_PATHS_2);
+	set_record_and_expect(interactions, &record_2, oscore_interaction_duplicated_token);
+
+	/* Writing a record with different key (URI paths) and token should pass. */	
+	memcpy(record_2.token, TOKEN_2, sizeof(TOKEN_2));
+	record_2.token_len = sizeof(TOKEN_2);
+	interactions_expected[1] = record_2;
+	interactions_expected[1].is_occupied = true;
+	set_record_and_compare(interactions, &record_2, ok, interactions_expected);
+
+	/* Writing an existing record with changed values should change the entry accordingly. */
+	record_1.request_piv[3] = 0x04;
+	record_1.request_piv_len = 4;
+	interactions_expected[0] = record_1;
+	interactions_expected[0].is_occupied = true;
+	set_record_and_compare(interactions, &record_1, ok, interactions_expected);
+
+	/* Reset the array and fill all entries with generated records.
+	   Adding another one should fail. */
+	struct oscore_interaction_t generated_records[OSCORE_INTERACTIONS_COUNT];
+	generate_and_fill(interactions, generated_records);
+	set_record_and_expect(interactions, &default_record, oscore_max_interactions);
+}
+
+/**
+ * @brief Test getting the record from interactions array.
+ */
+void t702_interactions_get_record_test(void)
+{
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
+	oscore_interactions_init(interactions);
+
+	/* Test null pointers. Null token is a valid value. */
+	struct oscore_interaction_t * received_record;
+	get_record_and_expect(NULL, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), &received_record, wrong_parameter);
+	get_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), NULL, wrong_parameter);
+
+	/* Test too big token size. */
+	get_record_and_expect(interactions, TOKEN_DEFAULT, MAX_TOKEN_LEN + 1, &received_record, wrong_parameter);
+
+	/* Getting a not-stored record should fail. */
+	get_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), &received_record, oscore_interaction_not_found);
+	get_record_and_expect(interactions, NULL, 0, &received_record, oscore_interaction_not_found);
+	get_record_and_expect(interactions, NULL, 1, &received_record, oscore_interaction_not_found);
+
+	/* Writing a record, then getting it back should return the same data.
+	   Updating a record, then getting it back should return updated data. */
+	struct oscore_interaction_t record = default_record;
+	set_record_and_expect(interactions, &record, ok);
+	get_record_and_compare(interactions, &record);
+	record.request_piv[0] += 10;
+	set_record_and_expect(interactions, &record, ok);
+	get_record_and_compare(interactions, &record);
+
+	/* Reset the array and fill all entries with generated records.
+	   Reading all records should pass, but reading a non-stored record should fail. */
+	struct oscore_interaction_t generated_records[OSCORE_INTERACTIONS_COUNT];
+	generate_and_fill(interactions, generated_records);
+	for (size_t entry = 0; entry < OSCORE_INTERACTIONS_COUNT; entry++)
+	{
+		get_record_and_compare(interactions, &generated_records[entry]);
+	}
+	get_record_and_expect(interactions, default_record.token, default_record.token_len, &received_record, oscore_interaction_not_found);
+}
+
+/**
+ * @brief Test removing the record from interactions array.
+ */
+void t703_interactions_remove_record_test(void)
+{
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
+	oscore_interactions_init(interactions);
+
+	/* Test null pointers. Null token is a valid value. */
+	remove_record_and_expect(NULL, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), wrong_parameter);
+
+	/* Test too big token size. */
+	remove_record_and_expect(interactions, TOKEN_DEFAULT, MAX_TOKEN_LEN + 1, wrong_parameter);
+
+	/* Removing a not-stored record should fail. */
+	remove_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), oscore_interaction_not_found);
+	remove_record_and_expect(interactions, NULL, 0, oscore_interaction_not_found);
+	remove_record_and_expect(interactions, NULL, 1, oscore_interaction_not_found);
+
+	/* Adding, then removing a record should pass. */
+	struct oscore_interaction_t * received_record;
+	set_record_and_expect(interactions, &default_record, ok);
+	get_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), &received_record, ok);
+	remove_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), ok);
+	get_record_and_expect(interactions, TOKEN_DEFAULT, sizeof(TOKEN_DEFAULT), &received_record, oscore_interaction_not_found);
+	
+	/* Reset the array and fill all entries with generated records.
+	   Check if all generated records are properly stored.
+	   Remove the first two records, check if they're gone.
+	   Add the same two records, check if they're accessible.
+	   Add another record, it should fail due to lack of free slots.
+	   Check again if all generated records are properly stored. */
+	struct oscore_interaction_t generated_records[OSCORE_INTERACTIONS_COUNT];
+	generate_and_fill(interactions, generated_records);
+	for (size_t entry = 0; entry < OSCORE_INTERACTIONS_COUNT; entry++)
+	{
+		get_record_and_compare(interactions, &generated_records[entry]);
+	}
+	remove_record_and_expect(interactions, generated_records[0].token, generated_records[0].token_len, ok);
+	remove_record_and_expect(interactions, generated_records[1].token, generated_records[1].token_len, ok);
+	get_record_and_expect(interactions, generated_records[0].token, generated_records[0].token_len, &received_record, oscore_interaction_not_found);
+	get_record_and_expect(interactions, generated_records[1].token, generated_records[1].token_len, &received_record, oscore_interaction_not_found);
+	set_record_and_expect(interactions, &generated_records[0], ok);
+	set_record_and_expect(interactions, &generated_records[1], ok);
+	set_record_and_expect(interactions, &default_record, oscore_max_interactions);
+	for (size_t entry = 0; entry < OSCORE_INTERACTIONS_COUNT; entry++)
+	{
+		get_record_and_compare(interactions, &generated_records[entry]);
+	}
+}
+
+/**
+ * @brief Test specific usecases.
+ */
+void t704_interactions_usecases_test(void)
+{
+	struct oscore_interaction_t interactions[OSCORE_INTERACTIONS_COUNT];
+	oscore_interactions_init(interactions);
+	set_record_and_expect(interactions, &default_record, ok);
+
+	// Get the record, then set it again using the same pointer (without change).
+	struct oscore_interaction_t new_record_1 = default_record;
+	struct oscore_interaction_t * record_1;
+	get_record_and_expect(interactions, new_record_1.token, new_record_1.token_len, &record_1, ok);
+	zassert_mem_equal(record_1, &default_record, sizeof(struct oscore_interaction_t), "");
+	set_record_and_expect(interactions, record_1, ok); 
+		/* set_record call is redundant since record_1 already points to specific entry in interactions array.
+		Only called for test purposes. */
+
+	// Get the record, then set it again using the same pointer (with change).
+	struct oscore_interaction_t new_record_2 = default_record;
+	struct oscore_interaction_t * record_2;
+	get_record_and_expect(interactions, new_record_1.token, new_record_1.token_len, &record_1, ok);
+	zassert_mem_equal(record_1, &default_record, sizeof(struct oscore_interaction_t), "");
+	record_1->request_piv[0] += 1;
+	new_record_2.request_piv[0] += 1;
+	set_record_and_expect(interactions, record_1, ok);
+		/* set_record call is redundant since record_1 already points to specific entry in interactions array.
+		Only called for test purposes. */
+	get_record_and_expect(interactions, new_record_2.token, new_record_2.token_len, &record_2, ok);
+	zassert_mem_equal(record_2, &new_record_2, sizeof(struct oscore_interaction_t), "");
+}


### PR DESCRIPTION
Prior to this change, only one interaction was supported by single OSCORE context. This resulted in invalid values for `request_piv` and `request_kid` fields when one than one interaction were active.

Example behavior: when the client subscribed for notifications, they only got proper values of the fields when no other communication was performed inbetween. If any request was received by the server, `request_piv` and `request_kid` fields were overwritten with new values, and next notifications used them instead of the values from the initial subscription request.

The changes introduced a dictionary-like structure to properly store, read and update valid values for multiple interactions. It was then integrated with the overall encryption and decryption flow.

