### PR TITLE
Static analyzer fix: out of bound memory access

### DIFF
--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -49,6 +49,7 @@ enum err {
 	cbor_encoding_error = 119,
 	cbor_decoding_error = 120,
 	suites_i_list_to_long = 121,
+	suites_i_list_empty = 122,
 
 	/*OSCORE specific errors*/
 	not_oscore_pkt = 200,

--- a/src/edhoc/responder.c
+++ b/src/edhoc/responder.c
@@ -82,6 +82,10 @@ static inline enum err msg1_parse(uint8_t *msg1, uint32_t msg1_len,
 		suites_i[0] = (uint8_t)m._message_1_SUITES_I_int;
 		*suites_i_len = 1;
 	} else {
+		if (0 == m._SUITES_I__suite_suite_count) {
+			return suites_i_list_empty;
+		}
+
 		/*the initiator supports more than one suite*/
 		if (m._SUITES_I__suite_suite_count > *suites_i_len) {
 			return suites_i_list_to_long;


### PR DESCRIPTION
If **initiator** side will send empty list with supported cipher suites then **responder** side will not check this corner case. This result in _out of bound memory access_ on stack by `suites_i[-1]`. At the end access will be following: `suites_i[255]` because of `uint8_t` overflow.

Proposal solution is to return new error value: `suites_i_list_empty`.