### PR TITLE
Bump up of zcbor to latest release (version 0.7.0)

### DIFF
--- a/inc/cbor/edhoc_decode_bstr_type.h
+++ b/inc/cbor/edhoc_decode_bstr_type.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_bstr_type_types.h
+++ b/inc/cbor/edhoc_decode_bstr_type_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_cert.h
+++ b/inc/cbor/edhoc_decode_cert.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_cert_types.h
+++ b/inc/cbor/edhoc_decode_cert_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_id_cred_x.h
+++ b/inc/cbor/edhoc_decode_id_cred_x.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_id_cred_x_types.h
+++ b/inc/cbor/edhoc_decode_id_cred_x_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -86,23 +86,23 @@ struct id_cred_x_map_c5u {
 
 struct id_cred_x_map {
 	struct id_cred_x_map_kid_ _id_cred_x_map_kid;
-	uint_fast32_t _id_cred_x_map_kid_present;
+	bool _id_cred_x_map_kid_present;
 	struct id_cred_x_map_x5bag _id_cred_x_map_x5bag;
-	uint_fast32_t _id_cred_x_map_x5bag_present;
+	bool _id_cred_x_map_x5bag_present;
 	struct id_cred_x_map_x5chain _id_cred_x_map_x5chain;
-	uint_fast32_t _id_cred_x_map_x5chain_present;
+	bool _id_cred_x_map_x5chain_present;
 	struct id_cred_x_map_x5t_ _id_cred_x_map_x5t;
-	uint_fast32_t _id_cred_x_map_x5t_present;
+	bool _id_cred_x_map_x5t_present;
 	struct id_cred_x_map_x5u _id_cred_x_map_x5u;
-	uint_fast32_t _id_cred_x_map_x5u_present;
+	bool _id_cred_x_map_x5u_present;
 	struct id_cred_x_map_c5b _id_cred_x_map_c5b;
-	uint_fast32_t _id_cred_x_map_c5b_present;
+	bool _id_cred_x_map_c5b_present;
 	struct id_cred_x_map_c5c _id_cred_x_map_c5c;
-	uint_fast32_t _id_cred_x_map_c5c_present;
+	bool _id_cred_x_map_c5c_present;
 	struct id_cred_x_map_c5t_ _id_cred_x_map_c5t;
-	uint_fast32_t _id_cred_x_map_c5t_present;
+	bool _id_cred_x_map_c5t_present;
 	struct id_cred_x_map_c5u _id_cred_x_map_c5u;
-	uint_fast32_t _id_cred_x_map_c5u_present;
+	bool _id_cred_x_map_c5u_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_decode_int_type.h
+++ b/inc/cbor/edhoc_decode_int_type.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_int_type_types.h
+++ b/inc/cbor/edhoc_decode_int_type_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_message_1.h
+++ b/inc/cbor/edhoc_decode_message_1.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_message_1_types.h
+++ b/inc/cbor/edhoc_decode_message_1_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -30,7 +30,7 @@ struct message_1 {
 	union {
 		struct {
 			int32_t _SUITES_I__suite_suite[10];
-			uint_fast32_t _SUITES_I__suite_suite_count;
+			size_t _SUITES_I__suite_suite_count;
 		};
 		int32_t _message_1_SUITES_I_int;
 	};
@@ -48,7 +48,7 @@ struct message_1 {
 		_message_1_C_I_bstr,
 	} _message_1_C_I_choice;
 	struct zcbor_string _message_1_ead_1;
-	uint_fast32_t _message_1_ead_1_present;
+	bool _message_1_ead_1_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_decode_message_2.h
+++ b/inc/cbor/edhoc_decode_message_2.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_message_2_types.h
+++ b/inc/cbor/edhoc_decode_message_2_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_message_3.h
+++ b/inc/cbor/edhoc_decode_message_3.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_message_3_types.h
+++ b/inc/cbor/edhoc_decode_message_3_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_plaintext.h
+++ b/inc/cbor/edhoc_decode_plaintext.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_decode_plaintext_types.h
+++ b/inc/cbor/edhoc_decode_plaintext_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -86,23 +86,23 @@ struct map_c5u {
 
 struct map {
 	struct map_kid_ _map_kid;
-	uint_fast32_t _map_kid_present;
+	bool _map_kid_present;
 	struct map_x5bag _map_x5bag;
-	uint_fast32_t _map_x5bag_present;
+	bool _map_x5bag_present;
 	struct map_x5chain _map_x5chain;
-	uint_fast32_t _map_x5chain_present;
+	bool _map_x5chain_present;
 	struct map_x5t_ _map_x5t;
-	uint_fast32_t _map_x5t_present;
+	bool _map_x5t_present;
 	struct map_x5u _map_x5u;
-	uint_fast32_t _map_x5u_present;
+	bool _map_x5u_present;
 	struct map_c5b _map_c5b;
-	uint_fast32_t _map_c5b_present;
+	bool _map_c5b_present;
 	struct map_c5c _map_c5c;
-	uint_fast32_t _map_c5c_present;
+	bool _map_c5c_present;
 	struct map_c5t_ _map_c5t;
-	uint_fast32_t _map_c5t_present;
+	bool _map_c5t_present;
 	struct map_c5u _map_c5u;
-	uint_fast32_t _map_c5u_present;
+	bool _map_c5u_present;
 };
 
 struct plaintext {
@@ -118,7 +118,7 @@ struct plaintext {
 	} _plaintext_ID_CRED_x_choice;
 	struct zcbor_string _plaintext_SGN_or_MAC_x;
 	struct zcbor_string _plaintext_AD_x;
-	uint_fast32_t _plaintext_AD_x_present;
+	bool _plaintext_AD_x_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_encode_bstr_type.h
+++ b/inc/cbor/edhoc_encode_bstr_type.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -12,7 +12,6 @@
 #include <stddef.h>
 #include <string.h>
 #include "cbor/edhoc_encode_bstr_type_types.h"
-#include "zcbor_common.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/inc/cbor/edhoc_encode_bstr_type_types.h
+++ b/inc/cbor/edhoc_encode_bstr_type_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_data_2.h
+++ b/inc/cbor/edhoc_encode_data_2.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_data_2_types.h
+++ b/inc/cbor/edhoc_encode_data_2_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -38,7 +38,7 @@ struct data_2_C_I_ {
 
 struct data_2 {
 	struct data_2_C_I_ _data_2_C_I;
-	uint_fast32_t _data_2_C_I_present;
+	bool _data_2_C_I_present;
 	struct zcbor_string _data_2_G_Y;
 	union {
 		int32_t _data_2_C_R_int;

--- a/inc/cbor/edhoc_encode_enc_structure.h
+++ b/inc/cbor/edhoc_encode_enc_structure.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_enc_structure_types.h
+++ b/inc/cbor/edhoc_encode_enc_structure_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_id_cred_x.h
+++ b/inc/cbor/edhoc_encode_id_cred_x.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_id_cred_x_types.h
+++ b/inc/cbor/edhoc_encode_id_cred_x_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -86,23 +86,23 @@ struct id_cred_x_map_c5u {
 
 struct id_cred_x_map {
 	struct id_cred_x_map_kid_ _id_cred_x_map_kid;
-	uint_fast32_t _id_cred_x_map_kid_present;
+	bool _id_cred_x_map_kid_present;
 	struct id_cred_x_map_x5bag _id_cred_x_map_x5bag;
-	uint_fast32_t _id_cred_x_map_x5bag_present;
+	bool _id_cred_x_map_x5bag_present;
 	struct id_cred_x_map_x5chain _id_cred_x_map_x5chain;
-	uint_fast32_t _id_cred_x_map_x5chain_present;
+	bool _id_cred_x_map_x5chain_present;
 	struct id_cred_x_map_x5t_ _id_cred_x_map_x5t;
-	uint_fast32_t _id_cred_x_map_x5t_present;
+	bool _id_cred_x_map_x5t_present;
 	struct id_cred_x_map_x5u _id_cred_x_map_x5u;
-	uint_fast32_t _id_cred_x_map_x5u_present;
+	bool _id_cred_x_map_x5u_present;
 	struct id_cred_x_map_c5b _id_cred_x_map_c5b;
-	uint_fast32_t _id_cred_x_map_c5b_present;
+	bool _id_cred_x_map_c5b_present;
 	struct id_cred_x_map_c5c _id_cred_x_map_c5c;
-	uint_fast32_t _id_cred_x_map_c5c_present;
+	bool _id_cred_x_map_c5c_present;
 	struct id_cred_x_map_c5t_ _id_cred_x_map_c5t;
-	uint_fast32_t _id_cred_x_map_c5t_present;
+	bool _id_cred_x_map_c5t_present;
 	struct id_cred_x_map_c5u _id_cred_x_map_c5u;
-	uint_fast32_t _id_cred_x_map_c5u_present;
+	bool _id_cred_x_map_c5u_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_encode_info.h
+++ b/inc/cbor/edhoc_encode_info.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_info_types.h
+++ b/inc/cbor/edhoc_encode_info_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_int_type.h
+++ b/inc/cbor/edhoc_encode_int_type.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_int_type_types.h
+++ b/inc/cbor/edhoc_encode_int_type_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_1.h
+++ b/inc/cbor/edhoc_encode_message_1.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_1_types.h
+++ b/inc/cbor/edhoc_encode_message_1_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -30,7 +30,7 @@ struct message_1 {
 	union {
 		struct {
 			int32_t _SUITES_I__suite_suite[10];
-			uint_fast32_t _SUITES_I__suite_suite_count;
+			size_t _SUITES_I__suite_suite_count;
 		};
 		int32_t _message_1_SUITES_I_int;
 	};
@@ -48,7 +48,7 @@ struct message_1 {
 		_message_1_C_I_bstr,
 	} _message_1_C_I_choice;
 	struct zcbor_string _message_1_ead_1;
-	uint_fast32_t _message_1_ead_1_present;
+	bool _message_1_ead_1_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_encode_message_2.h
+++ b/inc/cbor/edhoc_encode_message_2.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_2_types.h
+++ b/inc/cbor/edhoc_encode_message_2_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_3.h
+++ b/inc/cbor/edhoc_encode_message_3.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_3_types.h
+++ b/inc/cbor/edhoc_encode_message_3_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_error.h
+++ b/inc/cbor/edhoc_encode_message_error.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_message_error_types.h
+++ b/inc/cbor/edhoc_encode_message_error_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */
@@ -40,7 +40,7 @@ struct message_error_SUITES_R_ {
 	union {
 		struct {
 			int32_t _SUITES_R__supported_supported[10];
-			uint_fast32_t _SUITES_R__supported_supported_count;
+			size_t _SUITES_R__supported_supported_count;
 		};
 		int32_t _message_error_SUITES_R_int;
 	};
@@ -52,10 +52,10 @@ struct message_error_SUITES_R_ {
 
 struct message_error {
 	struct message_error_C_x_ _message_error_C_x;
-	uint_fast32_t _message_error_C_x_present;
+	bool _message_error_C_x_present;
 	struct zcbor_string _message_error_DIAG_MSG;
 	struct message_error_SUITES_R_ _message_error_SUITES_R;
-	uint_fast32_t _message_error_SUITES_R_present;
+	bool _message_error_SUITES_R_present;
 };
 
 #ifdef __cplusplus

--- a/inc/cbor/edhoc_encode_sig_structure.h
+++ b/inc/cbor/edhoc_encode_sig_structure.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_sig_structure_types.h
+++ b/inc/cbor/edhoc_encode_sig_structure_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_th2.h
+++ b/inc/cbor/edhoc_encode_th2.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/edhoc_encode_th2_types.h
+++ b/inc/cbor/edhoc_encode_th2_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_aad_array.h
+++ b/inc/cbor/oscore_aad_array.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_aad_array_types.h
+++ b/inc/cbor/oscore_aad_array_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_enc_structure.h
+++ b/inc/cbor/oscore_enc_structure.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_enc_structure_types.h
+++ b/inc/cbor/oscore_enc_structure_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_info.h
+++ b/inc/cbor/oscore_info.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/inc/cbor/oscore_info_types.h
+++ b/inc/cbor/oscore_info_types.h
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_bstr_type.c
+++ b/src/cbor/edhoc_decode_bstr_type.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_cert.c
+++ b/src/cbor/edhoc_decode_cert.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_id_cred_x.c
+++ b/src/cbor/edhoc_decode_id_cred_x.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_int_type.c
+++ b/src/cbor/edhoc_decode_int_type.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_message_1.c
+++ b/src/cbor/edhoc_decode_message_1.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_message_2.c
+++ b/src/cbor/edhoc_decode_message_2.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_message_3.c
+++ b/src/cbor/edhoc_decode_message_3.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_decode_plaintext.c
+++ b/src/cbor/edhoc_decode_plaintext.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_bstr_type.c
+++ b/src/cbor/edhoc_encode_bstr_type.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_data_2.c
+++ b/src/cbor/edhoc_encode_data_2.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_enc_structure.c
+++ b/src/cbor/edhoc_encode_enc_structure.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_id_cred_x.c
+++ b/src/cbor/edhoc_encode_id_cred_x.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_info.c
+++ b/src/cbor/edhoc_encode_info.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_int_type.c
+++ b/src/cbor/edhoc_encode_int_type.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_message_1.c
+++ b/src/cbor/edhoc_encode_message_1.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_message_2.c
+++ b/src/cbor/edhoc_encode_message_2.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_message_3.c
+++ b/src/cbor/edhoc_encode_message_3.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_message_error.c
+++ b/src/cbor/edhoc_encode_message_error.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_sig_structure.c
+++ b/src/cbor/edhoc_encode_sig_structure.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/edhoc_encode_th2.c
+++ b/src/cbor/edhoc_encode_th2.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/oscore_aad_array.c
+++ b/src/cbor/oscore_aad_array.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/oscore_enc_structure.c
+++ b/src/cbor/oscore_enc_structure.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/cbor/oscore_info.c
+++ b/src/cbor/oscore_info.c
@@ -1,5 +1,5 @@
 /*
- * Generated using zcbor version 0.6.99
+ * Generated using zcbor version 0.7.0
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3
  */

--- a/src/edhoc/bstr_encode_decode.c
+++ b/src/edhoc/bstr_encode_decode.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0 or MIT
  */
 
+#include "zcbor_common.h"
 #include "cbor/edhoc_encode_bstr_type.h"
 #include "cbor/edhoc_decode_bstr_type.h"
-#include "zcbor_common.h"
 
 #include "common/oscore_edhoc_error.h"
 #include "common/print_util.h"

--- a/src/edhoc/initiator.c
+++ b/src/edhoc/initiator.c
@@ -9,6 +9,7 @@
    except according to those terms.
 */
 
+#include <stdbool.h>
 #include "edhoc_internal.h"
 
 #include "common/crypto_wrapper.h"
@@ -122,7 +123,7 @@ enum err msg1_gen(const struct edhoc_initiator_context *c,
 		m1._message_1_ead_1.len = c->ead_1.len;
 		m1._message_1_ead_1_present = true;
 	} else {
-		m1._message_1_ead_1_present = 0;
+		m1._message_1_ead_1_present = false;
 	}
 
 	size_t payload_len_out;

--- a/src/edhoc/plaintext_decode.c
+++ b/src/edhoc/plaintext_decode.c
@@ -10,7 +10,7 @@
 */
 
 #include <stdint.h>
-
+#include <stdbool.h>
 
 
 #include "edhoc/retrieve_cred.h"

--- a/src/edhoc/plaintext_encode.c
+++ b/src/edhoc/plaintext_encode.c
@@ -27,14 +27,14 @@
 
 enum err id_cred2kid(const struct byte_array *id_cred, struct byte_array *kid)
 {
-	struct id_cred_x_map map;
+	struct id_cred_x_map map = {0};
 	size_t payload_len_out;
 	size_t decode_len = 0;
 	TRY_EXPECT(cbor_decode_id_cred_x_map(id_cred->ptr, id_cred->len, &map,
 					     &decode_len),
 		   0);
 
-	if (map._id_cred_x_map_kid_present != 0) {
+	if (map._id_cred_x_map_kid_present) {
 		TRY_EXPECT(
 			cbor_encode_int_type_i(
 				kid->ptr, kid->len,

--- a/src/edhoc/retrieve_cred.c
+++ b/src/edhoc/retrieve_cred.c
@@ -151,24 +151,24 @@ enum err retrieve_cred(bool static_dh_auth, struct cred_array *cred_array,
 		       struct byte_array *pk, struct byte_array *g)
 {
 	size_t decode_len = 0;
-	struct id_cred_x_map map;
+	struct id_cred_x_map map = {0};
 
 	TRY_EXPECT(cbor_decode_id_cred_x_map(id_cred->ptr, id_cred->len, &map,
 					     &decode_len),
 		   0);
 	/*the cred should be locally available on the device if 
 	kid, x5u, x5t, c5u, c5t is used*/
-	if ((map._id_cred_x_map_kid_present != 0) ||
-	    (map._id_cred_x_map_x5u_present != 0) ||
-	    (map._id_cred_x_map_x5t_present != 0) ||
-	    (map._id_cred_x_map_c5u_present != 0) ||
-	    (map._id_cred_x_map_c5t_present != 0)) {
+	if (map._id_cred_x_map_kid_present ||
+	    map._id_cred_x_map_x5u_present ||
+	    map._id_cred_x_map_x5t_present ||
+	    map._id_cred_x_map_c5u_present ||
+	    map._id_cred_x_map_c5t_present) {
 		TRY(get_local_cred(static_dh_auth, cred_array, id_cred, cred,
 				   pk, g));
 		return ok;
 	}
 	/*x5chain*/
-	else if (map._id_cred_x_map_x5chain_present != 0) {
+	else if (map._id_cred_x_map_x5chain_present) {
 		struct const_byte_array cert = BYTE_ARRAY_INIT(
 			map._id_cred_x_map_x5chain._id_cred_x_map_x5chain.value,
 			(uint32_t)map._id_cred_x_map_x5chain
@@ -179,7 +179,7 @@ enum err retrieve_cred(bool static_dh_auth, struct cred_array *cred_array,
 		return ok;
 	}
 	/*x5bag*/
-	else if (map._id_cred_x_map_x5bag_present != 0) {
+	else if (map._id_cred_x_map_x5bag_present) {
 		struct const_byte_array cert = BYTE_ARRAY_INIT(
 			map._id_cred_x_map_x5bag._id_cred_x_map_x5bag.value,
 			(uint32_t)map._id_cred_x_map_x5bag._id_cred_x_map_x5bag
@@ -189,7 +189,7 @@ enum err retrieve_cred(bool static_dh_auth, struct cred_array *cred_array,
 		return ok;
 	}
 	/*c5c*/
-	else if (map._id_cred_x_map_c5c_present != 0) {
+	else if (map._id_cred_x_map_c5c_present) {
 		struct const_byte_array cert = BYTE_ARRAY_INIT(
 			map._id_cred_x_map_c5c._id_cred_x_map_c5c.value,
 			(uint32_t)map._id_cred_x_map_c5c._id_cred_x_map_c5c.len);
@@ -198,7 +198,7 @@ enum err retrieve_cred(bool static_dh_auth, struct cred_array *cred_array,
 		return ok;
 	}
 	/*c5b*/
-	else if (map._id_cred_x_map_c5b_present != 0) {
+	else if (map._id_cred_x_map_c5b_present) {
 		struct const_byte_array cert = BYTE_ARRAY_INIT(
 			map._id_cred_x_map_c5b._id_cred_x_map_c5b.value,
 			(uint32_t)map._id_cred_x_map_c5b._id_cred_x_map_c5b.len);


### PR DESCRIPTION
Scope of changes:
- detached zcbor HEAD to version 0.7.0.
- comments changes 0.6.99 to 0.7.0.
- regeneration of structures.
- fix compilation warnings.