### PR TITLE
Fixes found during integration

### DIFF
--- a/inc/common/byte_array.h
+++ b/inc/common/byte_array.h
@@ -78,7 +78,7 @@ enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src,
 */
 #ifdef VLA
 #define BYTE_ARRAY_NEW(NAME, BUF_SIZE, SIZE)                                   \
-	if (SIZE < 0) {                                                        \
+	if (SIZE < 0 || SIZE > BUF_SIZE) {                                     \
 		return vla_insufficient_size;                                  \
 	}                                                                      \
 	struct byte_array NAME;                                                \

--- a/inc/common/byte_array.h
+++ b/inc/common/byte_array.h
@@ -94,7 +94,7 @@ enum err byte_array_cpy(struct byte_array *dest, const struct byte_array *src,
 #define BYTE_ARRAY_NEW(NAME, BUF_SIZE, SIZE)                                   \
 	TRY(check_buffer_size(BUF_SIZE, SIZE));                                \
 	struct byte_array NAME;                                                \
-	uint8_t NAME##_buf[SIZE];                                              \
+	uint8_t NAME##_buf[BUF_SIZE];                                          \
 	if (SIZE == 0) {                                                       \
 		NAME = NULL_ARRAY;                                             \
 	} else {                                                               \

--- a/makefile_config.mk
+++ b/makefile_config.mk
@@ -50,6 +50,7 @@ CBOR_ENGINE += -DZCBOR
 # RAM optimization
 ################################################################################
 # Compute the length of buffers at runtime (variable length array VLA)
+# Please note that: we do not support this feature under Windows with MSVC (lack of support for VLA).
 #FEATURES += -DVLA
 
 ################################################################################

--- a/src/edhoc/responder.c
+++ b/src/edhoc/responder.c
@@ -276,9 +276,15 @@ enum err msg3_process(struct edhoc_responder_context *c,
 
 	PRINTF("PLAINTEXT3_SIZE: %d\n", PLAINTEXT3_SIZE);
 	PRINTF("ctxt3.len: %d\n", ctxt3.len);
+#if defined(_WIN32)
+	BYTE_ARRAY_NEW(ptxt3,
+		       PLAINTEXT3_SIZE + 16, // 16 is max aead mac length
+		       ctxt3.len);
+#else
 	BYTE_ARRAY_NEW(ptxt3,
 		       PLAINTEXT3_SIZE + get_aead_mac_len(rc->suite.edhoc_aead),
 		       ctxt3.len);
+#endif
 
 	TRY(ciphertext_decrypt_split(CIPHERTEXT3, &rc->suite, &id_cred_i,
 				     &sign_or_mac, &rc->ead, &rc->prk_3e2m,

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -216,7 +216,7 @@ static inline enum err plaintext_setup(struct o_coap_packet *in_o_coap,
 					      E_options[i].len);
 	}
 	/* Setup buffer */
-	BYTE_ARRAY_NEW(e_opt_serial, E_OPTIONS_BUFF_MAX_LEN, e_opt_serial_len);
+	BYTE_ARRAY_NEW(e_opt_serial, E_OPTIONS_BUFF_MAX_LEN, E_OPTIONS_BUFF_MAX_LEN);
 
 	/* Convert all E-options structure to byte string, and copy it to 
 	output*/

--- a/src/oscore/option.c
+++ b/src/oscore/option.c
@@ -94,9 +94,8 @@ enum err echo_val_is_fresh(struct byte_array *cache_val,
 
 	for (uint8_t i = 0; i < E_options_cnt; i++) {
 		if (E_options[i].option_number == ECHO) {
-			if (0 == memcmp(E_options[i].value, cache_val->ptr,
-					cache_val->len) &&
-			    cache_val->len == E_options[i].len) {
+			if (cache_val->len == E_options[i].len &&
+			    0 == memcmp(E_options[i].value, cache_val->ptr, cache_val->len) ) {
 				PRINT_MSG("ECHO option check -- OK\n");
 				return ok;
 			} else {


### PR DESCRIPTION
- additional protection for VLA buffer check against unsigned integer overflow.
- for `responder.c` preprocessor condition for windows compiler msvc which does not support VLA at all.
- fixes for oscore found on internal tests:
  - wrong buffer size with enabled VLA.
  - lazy check to defer memcmp. 