### PR TITLE
fix: inner_outer_option_split not working if two bytes options are present

### DIFF
--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -52,10 +52,10 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 	/* Initialize to 0 */
 	*e_options_len = 0;
 
-	uint8_t temp_option_nr = 0;
+	uint16_t temp_option_nr = 0;
 	uint16_t temp_len = 0;
-	uint8_t temp_E_option_delta_sum = 0;
-	uint8_t temp_U_option_delta_sum = 0;
+	uint16_t temp_E_option_delta_sum = 0;
+	uint16_t temp_U_option_delta_sum = 0;
 
 	if (MAX_OPTION_COUNT < in_o_coap->options_cnt) {
 		return too_many_options;
@@ -67,11 +67,11 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 			opt_extra_bytes(in_o_coap->options[i].len);
 
 		temp_option_nr =
-			(uint8_t)(temp_option_nr + in_o_coap->options[i].delta);
+			(uint16_t)(temp_option_nr + in_o_coap->options[i].delta);
 		temp_len = in_o_coap->options[i].len;
 
 		/* process special options, see 4.1.3 in RFC8613*/
-		/* if the option does not need special processing just put it in the 
+		/* if the option does not need special processing just put it in the
 		E or U array*/
 
 		switch (temp_option_nr) {
@@ -80,7 +80,7 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 			and outer option in a OSCORE packet.*/
 
 			/*
-			* Inner option has value NULL if notification or the original value 
+			* Inner option has value NULL if notification or the original value
 			* in the coap packet if registration/cancellation.
 			*/
 			e_options[*e_options_cnt].delta =
@@ -110,7 +110,7 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 
 			/* Update delta sum of E-options */
 			temp_E_option_delta_sum =
-				(uint8_t)(temp_E_option_delta_sum +
+				(uint16_t)(temp_E_option_delta_sum +
 					  e_options[*e_options_cnt].delta);
 
 			/* Increment E-options count */
@@ -130,7 +130,7 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 
 			/* Update delta sum of E-options */
 			temp_U_option_delta_sum =
-				(uint8_t)(temp_U_option_delta_sum +
+				(uint16_t)(temp_U_option_delta_sum +
 					  U_options[*U_options_cnt].delta);
 
 			/* Increment E-options count */
@@ -151,9 +151,9 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 				e_options[*e_options_cnt].option_number =
 					temp_option_nr;
 
-				/* Update delta sum of E-options */
+					/* Update delta sum of E-options */
 				temp_E_option_delta_sum =
-					(uint8_t)(temp_E_option_delta_sum +
+					(uint16_t)(temp_E_option_delta_sum +
 						  e_options[*e_options_cnt]
 							  .delta);
 
@@ -176,7 +176,7 @@ STATIC enum err inner_outer_option_split(struct o_coap_packet *in_o_coap,
 
 				/* Update delta sum of E-options */
 				temp_U_option_delta_sum =
-					(uint8_t)(temp_U_option_delta_sum +
+					(uint16_t)(temp_U_option_delta_sum +
 						  U_options[*U_options_cnt]
 							  .delta);
 
@@ -208,7 +208,7 @@ static inline enum err plaintext_setup(struct o_coap_packet *in_o_coap,
 	/* Add code to plaintext */
 	*temp_plaintext_ptr = in_o_coap->header.code;
 
-	/* Calculate the maximal length of all options, i.e. all options 
+	/* Calculate the maximal length of all options, i.e. all options
 	have two bytes extra delta and length */
 	uint16_t e_opt_serial_len = 0;
 	for (uint8_t i = 0; i < E_options_cnt; i++) {
@@ -219,7 +219,7 @@ static inline enum err plaintext_setup(struct o_coap_packet *in_o_coap,
 	BYTE_ARRAY_NEW(e_opt_serial, E_OPTIONS_BUFF_MAX_LEN,
 		       E_OPTIONS_BUFF_MAX_LEN);
 
-	/* Convert all E-options structure to byte string, and copy it to 
+	/* Convert all E-options structure to byte string, and copy it to
 	output*/
 	TRY(options_serialize(E_options, E_options_cnt, &e_opt_serial));
 
@@ -268,10 +268,10 @@ static inline uint32_t get_oscore_opt_val_len(uint32_t piv_len,
 
 /**
  * @brief   Generate an OSCORE option.
- * @param   piv set to the trimmed sender sequence number in requests or NULL 
+ * @param   piv set to the trimmed sender sequence number in requests or NULL
  *          in responses
  * @param   kid set to Sender ID in requests or NULL in responses
- * @param   kid_context set to ID context in request when present. If not 
+ * @param   kid_context set to ID context in request when present. If not
  *          present or a response set to NULL
  * @param   oscore_option: output pointer OSCORE option structure
  * @return  err
@@ -446,9 +446,9 @@ STATIC enum err oscore_pkg_generate(struct o_coap_packet *in_o_coap,
 
 /**
  * @brief Increment Sender Sequence Number and call the function to periodically write it to NVM.
- * 
+ *
  * @param c Security context.
- * @return enum err 
+ * @return enum err
  */
 static enum err generate_new_ssn(struct context *c)
 {
@@ -495,13 +495,13 @@ static bool needs_new_piv(enum o_coap_msg msg_type, enum echo_state echo_state)
  * @brief Wrapper function with common operations for encrypting the payload.
  *        These operations are shared in all possible scenarios.
  *        For more info, see RFC8616 8.1 and 8.3.
- * 
+ *
  * @param plaintext Input plaintext to be encrypted.
  * @param ciphertext Output encrypted payload for the OSCORE packet.
  * @param c Security context.
  * @param input_coap Input coap packet.
  * @param oscore_option Output OSCORE option.
- * @return enum err 
+ * @return enum err
  */
 static enum err encrypt_wrapper(struct byte_array *plaintext,
 				struct byte_array *ciphertext,
@@ -541,7 +541,7 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 	/* Generate OSCORE option based on selected values. */
 	TRY(oscore_option_generate(&piv, &kid, &kid_context, oscore_option));
 
-	/* AAD shares the same format for both requests and responses, 
+	/* AAD shares the same format for both requests and responses,
 	   yet request_kid and request_piv fields are only used by responses.
 	   For more details, see 5.4. */
 	BYTE_ARRAY_NEW(aad, MAX_AAD_LEN, MAX_AAD_LEN);
@@ -577,7 +577,7 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 /**
  *@brief 	Converts a CoAP packet to OSCORE packet
  *@note		For messaging layer packets (simple ACK with no payload, code 0.00),
- *			encryption is dismissed and raw input buffer is copied, 
+ *			encryption is dismissed and raw input buffer is copied,
  *			as specified at section 4.2 in RFC8613.
  *@param	buf_o_coap a buffer containing a CoAP packet
  *@param	buf_o_coap_len length of the CoAP buffer

--- a/test/oscore_unit_tests/unit_test_coap2oscore.c
+++ b/test/oscore_unit_tests/unit_test_coap2oscore.c
@@ -67,8 +67,8 @@ void t100_inner_outer_option_split__no_special_options(void)
 	struct o_coap_packet coap_pkt = {
 		.header = header,
 		.token = NULL,
-		.options_cnt = 4,
-		.options = { 
+		.options_cnt = 6,
+		.options = {
                 /*If-Match (opt num 1, E)*/
                 { .delta = 1,
 			       .len = 0,
@@ -83,19 +83,29 @@ void t100_inner_outer_option_split__no_special_options(void)
 			    { .delta = 8,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = 12 } , 
+			       .option_number = CONTENT_FORMAT },
                 /*Proxy-Uri (opt num 35, U)*/
 			    { .delta = 23,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = PROXY_URI }
-                   },
+			       .option_number = PROXY_URI },
+				/*Custom option 1 (opt num 0xFE00, E)*/
+			    { .delta = 64989,
+			       .len = 0,
+			       .value = NULL,
+			       .option_number = 0xFE00 },
+				/*Custom option 1 (opt num 0xFE10, E)*/
+			    { .delta = 16,
+			       .len = 0,
+			       .value = NULL,
+			       .option_number = 0xFE10 }
+			},
 		.payload.len = 0,
 		.payload.ptr = NULL,
 	};
 
-	struct o_coap_option inner_options[5];
-	struct o_coap_option outer_options[5];
+	struct o_coap_option inner_options[6];
+	struct o_coap_option outer_options[6];
 	memset(inner_options, 0, sizeof(inner_options));
 	memset(outer_options, 0, sizeof(outer_options));
 	uint16_t inner_options_len = 0;
@@ -116,8 +126,17 @@ void t100_inner_outer_option_split__no_special_options(void)
 		{ .delta = 8,
 		  .len = 0,
 		  .value = NULL,
-		  .option_number = CONTENT_FORMAT }
-
+		  .option_number = CONTENT_FORMAT },
+		/*Custom option 1 (opt num 0xFE00, E)*/
+		{ .delta = 65012,
+			.len = 0,
+			.value = NULL,
+			.option_number = 0xFE00 },
+		/*Custom option 1 (opt num 0xFE10, E)*/
+		{ .delta = 16,
+			.len = 0,
+			.value = NULL,
+			.option_number = 0xFE10 }
 	};
 	expected_inner_options_cnt = sizeof(expected_inner_options) /
 				     sizeof(expected_inner_options[0]);
@@ -151,8 +170,8 @@ void t100_inner_outer_option_split__no_special_options(void)
 }
 
 /**
- * @brief   Tests the function inner_outer_option_split with Observe option 
- *          indicating a notification. This function tests the behavior of 
+ * @brief   Tests the function inner_outer_option_split with Observe option
+ *          indicating a notification. This function tests the behavior of
  *          the server preparing a response
  */
 void t101_inner_outer_option_split__with_observe_notification(void)
@@ -173,8 +192,8 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 	struct o_coap_packet coap_pkt = {
 		.header = header,
 		.token = NULL,
-		.options_cnt = 5,
-		.options = { 
+		.options_cnt = 7,
+		.options = {
                 /*If-Match (opt num 1, E)*/
                 { .delta = 1,
 			       .len = 0,
@@ -194,19 +213,29 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 			    { .delta = 6,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = CONTENT_FORMAT } , 
+			       .option_number = CONTENT_FORMAT } ,
                 /*Proxy-Uri (opt num 35, U)*/
 			    { .delta = 23,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = PROXY_URI }
+			       .option_number = PROXY_URI },
+				/*Custom option 1 (opt num 0xFE00, E)*/
+				{ .delta = 64989,
+					.len = 0,
+					.value = NULL,
+					.option_number = 0xFE00 },
+				/*Custom option 1 (opt num 0xFE10, E)*/
+				{ .delta = 16,
+					.len = 0,
+					.value = NULL,
+					.option_number = 0xFE10 }
                    },
 		.payload.len = 0,
 		.payload.ptr = NULL,
 	};
 
-	struct o_coap_option inner_options[5];
-	struct o_coap_option outer_options[5];
+	struct o_coap_option inner_options[7];
+	struct o_coap_option outer_options[7];
 	memset(inner_options, 0, sizeof(inner_options));
 	memset(outer_options, 0, sizeof(outer_options));
 	uint16_t inner_options_len = 0;
@@ -221,7 +250,7 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 		  .option_number = IF_MATCH },
 		/*Etag (opt num 4, E)*/
 		{ .delta = 3, .len = 0, .value = NULL, .option_number = ETAG },
-		/*Observe(opt num 6): The inner observe option shall have 
+		/*Observe(opt num 6): The inner observe option shall have
         no value, see 4.1.3.5.2 in RFC8613*/
 		{ .delta = 2,
 		  .len = 0,
@@ -231,7 +260,17 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 		{ .delta = 6,
 		  .len = 0,
 		  .value = NULL,
-		  .option_number = CONTENT_FORMAT }
+		  .option_number = CONTENT_FORMAT },
+		/*Custom option 1 (opt num 0xFE00, E)*/
+		{ .delta = 65012,
+			.len = 0,
+			.value = NULL,
+			.option_number = 0xFE00 },
+		/*Custom option 1 (opt num 0xFE10, E)*/
+		{ .delta = 16,
+			.len = 0,
+			.value = NULL,
+			.option_number = 0xFE10 }
 
 	};
 	uint8_t expected_inner_options_cnt =
@@ -239,7 +278,7 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 
 	struct o_coap_option expected_outer_options[2];
 	memset(expected_outer_options, 0, sizeof(expected_outer_options));
-	/*Observe(opt num 6): The outer observe option may have 
+	/*Observe(opt num 6): The outer observe option may have
         a value as in the original coap packet, see 4.1.3.5.2 in RFC8613*/
 	expected_outer_options[0].delta = 6;
 	expected_outer_options[0].len = sizeof(observe_val);
@@ -274,8 +313,8 @@ void t101_inner_outer_option_split__with_observe_notification(void)
 }
 
 /**
- * @brief   Tests the function inner_outer_option_split with Observe option 
- *          indicating a registration. This function tests the behavior of 
+ * @brief   Tests the function inner_outer_option_split with Observe option
+ *          indicating a registration. This function tests the behavior of
  *          the client preparing a request
  */
 void t102_inner_outer_option_split__with_observe_registration(void)
@@ -297,7 +336,7 @@ void t102_inner_outer_option_split__with_observe_registration(void)
 		.header = header,
 		.token = NULL,
 		.options_cnt = 5,
-		.options = { 
+		.options = {
                 /*If-Match (opt num 1, E)*/
                 { .delta = 1,
 			       .len = 0,
@@ -317,7 +356,7 @@ void t102_inner_outer_option_split__with_observe_registration(void)
 			    { .delta = 6,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = CONTENT_FORMAT } , 
+			       .option_number = CONTENT_FORMAT } ,
                 /*Proxy-Uri (opt num 35, U)*/
 			    { .delta = 23,
 			       .len = 0,
@@ -349,7 +388,7 @@ void t102_inner_outer_option_split__with_observe_registration(void)
 	expected_inner_options[1].len = 0;
 	expected_inner_options[1].value = NULL;
 	expected_inner_options[1].option_number = ETAG;
-	/*Observe(opt num 6): The inner observe option shall have 
+	/*Observe(opt num 6): The inner observe option shall have
         the value contained in the original coap packet, see 4.1.3.5.1 in RFC8613*/
 	expected_inner_options[2].delta = 2;
 	expected_inner_options[2].len = sizeof(observe_val);
@@ -364,7 +403,7 @@ void t102_inner_outer_option_split__with_observe_registration(void)
 	struct o_coap_option expected_outer_options[2];
 	memset(expected_outer_options, 0, sizeof(expected_outer_options));
 
-	/*Observe(opt num 6): The outer observe option must have 
+	/*Observe(opt num 6): The outer observe option must have
         a value as in the original coap packet, see 4.1.3.5.1 in RFC8613*/
 	expected_outer_options[0].delta = 6;
 	expected_outer_options[0].len = sizeof(observe_val);
@@ -399,10 +438,10 @@ void t102_inner_outer_option_split__with_observe_registration(void)
 }
 
 /**
- * @brief   Tests oscore_pkg_generate with an observe option. 
- *          The observe option indicates registration, which is a 
+ * @brief   Tests oscore_pkg_generate with an observe option.
+ *          The observe option indicates registration, which is a
  * 			request message.
- * 
+ *
  */
 void t103_oscore_pkg_generate__request_with_observe_registration(void)
 {
@@ -423,7 +462,7 @@ void t103_oscore_pkg_generate__request_with_observe_registration(void)
 		.header = header,
 		.token = NULL,
 		.options_cnt = 5,
-		.options = { 
+		.options = {
                 /*If-Match (opt num 1, E)*/
                 { .delta = 1,
 			       .len = 0,
@@ -443,7 +482,7 @@ void t103_oscore_pkg_generate__request_with_observe_registration(void)
 			    { .delta = 6,
 			       .len = 0,
 			       .value = NULL,
-			       .option_number = CONTENT_FORMAT } , 
+			       .option_number = CONTENT_FORMAT } ,
                 /*Proxy-Uri (opt num 35, U)*/
 			    { .delta = 23,
 			       .len = 0,
@@ -455,7 +494,7 @@ void t103_oscore_pkg_generate__request_with_observe_registration(void)
 	};
 
 	struct o_coap_option u_options[] = {
-		/*Observe(opt num 6): The outer observe option must have 
+		/*Observe(opt num 6): The outer observe option must have
         a value as in the original coap packet, see 4.1.3.5.1 in RFC8613*/
 		{ .delta = 6,
 		  .len = sizeof(observe_val),
@@ -524,10 +563,10 @@ void t103_oscore_pkg_generate__request_with_observe_registration(void)
 }
 
 /**
- * @brief   Tests oscore_pkg_generate with an observe option. 
+ * @brief   Tests oscore_pkg_generate with an observe option.
  *          The observe option indicates notification.
  * 			The message is a response.
- * 
+ *
  */
 void t104_oscore_pkg_generate__request_with_observe_notification(void)
 {
@@ -548,7 +587,7 @@ void t104_oscore_pkg_generate__request_with_observe_notification(void)
 		.header = header,
 		.token = NULL,
 		.options_cnt = 1,
-		.options = { 
+		.options = {
                 /*Observe (opt num 6, EU)*/
 			    { .delta = 6,
 			       .len = sizeof(observe_val),
@@ -560,7 +599,7 @@ void t104_oscore_pkg_generate__request_with_observe_notification(void)
 	};
 
 	struct o_coap_option u_options[] = {
-		/*Observe(opt num 6): The outer observe option may have 
+		/*Observe(opt num 6): The outer observe option may have
         a value as in the original coap packet, see 4.1.3.5.1 in RFC8613*/
 		{ .delta = 6,
 		  .len = sizeof(observe_val),


### PR DESCRIPTION
This PR intends to fix #69

I also extended unit tests to include two-bytes options.