### PR TITLE
fix(samples): set content-format for edhoc

### DIFF
--- a/samples/linux_edhoc/initiator/src/main.cpp
+++ b/samples/linux_edhoc/initiator/src/main.cpp
@@ -86,6 +86,7 @@ enum err tx(void *sock, struct byte_array *data)
 	pdu->setVersion(1);
 	pdu->setType(CoapPDU::COAP_CONFIRMABLE);
 	pdu->setCode(CoapPDU::COAP_POST);
+	pdu->setContentFormat(CoapPDU::COAP_CONTENT_FORMAT_APP_EDHOC_CBOR_SEQ);
 	pdu->setToken((uint8_t *)&(++token), sizeof(token));
 	pdu->setMessageID(mid++);
 	pdu->setURI((char *)".well-known/edhoc", 17);

--- a/samples/linux_edhoc/responder/src/main.cpp
+++ b/samples/linux_edhoc/responder/src/main.cpp
@@ -114,6 +114,7 @@ enum err ead_process(void *params, struct byte_array *ead13)
 enum err tx(void *sock, struct byte_array *data)
 {
 	txPDU->setCode(CoapPDU::COAP_CHANGED);
+	txPDU->setContentFormat(CoapPDU::COAP_CONTENT_FORMAT_APP_EDHOC_CBOR_SEQ);
 	txPDU->setPayload(data->ptr, data->len);
 	send_coap_reply(sock, txPDU);
 	return ok;

--- a/samples/linux_edhoc_oscore/initiator_client/src/main.cpp
+++ b/samples/linux_edhoc_oscore/initiator_client/src/main.cpp
@@ -87,6 +87,7 @@ enum err tx(void *sock, struct byte_array *data)
 	pdu->setVersion(1);
 	pdu->setType(CoapPDU::COAP_CONFIRMABLE);
 	pdu->setCode(CoapPDU::COAP_POST);
+	pdu->setContentFormat(CoapPDU::COAP_CONTENT_FORMAT_APP_EDHOC_CBOR_SEQ);
 	pdu->setToken((uint8_t *)&(++token), sizeof(token));
 	pdu->setMessageID(mid++);
 	pdu->setURI((char *)".well-known/edhoc", 17);

--- a/samples/linux_edhoc_oscore/responder_server/src/main.cpp
+++ b/samples/linux_edhoc_oscore/responder_server/src/main.cpp
@@ -138,6 +138,7 @@ enum err ead_process(void *params, struct byte_array *ead13)
 enum err tx(void *sock, struct byte_array *data)
 {
 	txPDU->setCode(CoapPDU::COAP_CHANGED);
+	txPDU->setContentFormat(CoapPDU::COAP_CONTENT_FORMAT_APP_EDHOC_CBOR_SEQ);
 	txPDU->setPayload(data->ptr, data->len);
 	send_coap_reply(sock, txPDU);
 	return ok;


### PR DESCRIPTION
Set the CoAP Content-Format option to application/edhoc+cbor-seq for both client (initiator) and server (responder) so it can be distinguished from non-EDHOC CoAP traffic, in accordance with RFC9528.
Currently, the client id is not parsed, so the content type "application/cid-edhoc+cbor-seq" is currently not used.

This way it is also correctly parsed in Wireshark (first 3 messages is current `main`, last 3 messages is with this PR)
<img width="2257" height="1010" alt="screenshot-Thu May 14 01:49:04 PM CEST 2026" src="https://github.com/user-attachments/assets/dc1f4fe2-27a7-46db-942f-41ec774b0422" />
